### PR TITLE
Add Grover's Search benchmark

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -22,6 +22,10 @@ criterion = "0.4.0"
 name = "gates"
 harness = false
 
+[[bench]]
+name = "grover"
+harness = false
+
 [lib]
 crate-type = ["staticlib","rlib"]
 bench = false

--- a/backend/benches/grover.rs
+++ b/backend/benches/grover.rs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::ffi::c_void;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use qir_backend::*;
+
+/// Benchmarks a simple Grover's search on 2 qubits for the pattern |01⟩. This has the benefit of
+/// being a deterministic instance of the algorithm, such that the correct pattern is always found with 100% probability.
+pub fn grover(c: &mut Criterion) {
+    c.bench_function("Simple Grover's Search Program", |b| {
+        b.iter(|| {
+            // Prepare a uniform superposition.
+            __quantum__qis__h__body(std::ptr::null_mut());
+            __quantum__qis__h__body(1 as *mut c_void);
+
+            // Reflect about the marked state, using an auxiliary qubit.
+            __quantum__qis__x__body(2 as *mut c_void);
+            __quantum__qis__h__body(2 as *mut c_void);
+            __quantum__qis__x__body(std::ptr::null_mut());
+            __quantum__qis__h__body(2 as *mut c_void);
+            __quantum__qis__t__adj(std::ptr::null_mut());
+            __quantum__qis__t__adj(1 as *mut c_void);
+            __quantum__qis__cnot__body(2 as *mut c_void, std::ptr::null_mut());
+            __quantum__qis__t__body(std::ptr::null_mut());
+            __quantum__qis__cnot__body(1 as *mut c_void, 2 as *mut c_void);
+            __quantum__qis__cnot__body(1 as *mut c_void, std::ptr::null_mut());
+            __quantum__qis__t__body(2 as *mut c_void);
+            __quantum__qis__t__adj(std::ptr::null_mut());
+            __quantum__qis__cnot__body(1 as *mut c_void, 2 as *mut c_void);
+            __quantum__qis__cnot__body(2 as *mut c_void, std::ptr::null_mut());
+            __quantum__qis__t__adj(2 as *mut c_void);
+            __quantum__qis__t__body(std::ptr::null_mut());
+            __quantum__qis__cnot__body(1 as *mut c_void, std::ptr::null_mut());
+            __quantum__qis__h__body(2 as *mut c_void);
+            __quantum__qis__x__body(std::ptr::null_mut());
+            __quantum__qis__h__body(2 as *mut c_void);
+            __quantum__qis__x__body(2 as *mut c_void);
+
+            // Reflect about the uniform superposition state.
+            __quantum__qis__h__body(1 as *mut c_void);
+            __quantum__qis__h__body(std::ptr::null_mut());
+            __quantum__qis__x__body(std::ptr::null_mut());
+            __quantum__qis__x__body(1 as *mut c_void);
+            __quantum__qis__cz__body(std::ptr::null_mut(), 1 as *mut c_void);
+            __quantum__qis__x__body(1 as *mut c_void);
+            __quantum__qis__x__body(std::ptr::null_mut());
+            __quantum__qis__h__body(std::ptr::null_mut());
+            __quantum__qis__h__body(1 as *mut c_void);
+
+            // At this point, the qubits should be in the pattern state with 100% probability.
+            // Take advantage of that by unpreparing the pattern (including the accumulated phase)
+            // and assert both qubits are back in the |0⟩ state.
+            __quantum__qis__z__body(1 as *mut c_void);
+            __quantum__qis__x__body(1 as *mut c_void);
+            __quantum__qis__assertzero__body(std::ptr::null_mut());
+            __quantum__qis__assertzero__body(1 as *mut c_void);
+        })
+    });
+}
+
+criterion_group!(benches, grover);
+criterion_main!(benches);

--- a/backend/src/simulator.rs
+++ b/backend/src/simulator.rs
@@ -33,9 +33,11 @@ impl QuantumSim {
     /// Creates a new sparse state quantum simulator object with empty initial state (no qubits allocated, no operations buffered).
     #[must_use]
     fn new() -> Self {
-        QuantumSim {
-            state: FxHashMap::default(),
+        let mut initial_state = FxHashMap::default();
+        initial_state.insert(BigUint::zero(), Complex64::one());
 
+        QuantumSim {
+            state: initial_state,
             id_map: FxHashMap::default(),
         }
     }
@@ -45,11 +47,6 @@ impl QuantumSim {
     /// if those identifiers are available.
     #[must_use]
     pub(crate) fn allocate(&mut self) -> usize {
-        if self.id_map.is_empty() {
-            // Add the intial value for the zero state.
-            self.state.insert(BigUint::zero(), Complex64::one());
-        }
-
         // Add the new entry into the FxHashMap at the first available sequential ID.
         let mut sorted_keys: Vec<&usize> = self.id_map.keys().collect();
         sorted_keys.sort();
@@ -72,40 +69,24 @@ impl QuantumSim {
     ///
     /// The function will panic if the given id does not correpsond to an allocated qubit.
     pub(crate) fn release(&mut self, id: usize) {
-        // Since it is easier to release a contiguous half of the state, find the qubit
-        // with the last location and swap that with the qubit to be released.
-        let n_qubits = self.id_map.len();
-        let loc = *self
+        let loc = self
             .id_map
-            .get(&id)
+            .remove(&id)
             .unwrap_or_else(|| panic!("Unable to find qubit with id {}.", id));
-        let last_loc = n_qubits - 1;
-        if last_loc != loc {
-            let last_id = *self
-                .id_map
-                .iter()
-                .find(|(_, &value)| value == last_loc)
-                .unwrap()
-                .0;
-            self.swap_qubit_state(loc, last_loc);
-            *(self.id_map.get_mut(&last_id).unwrap()) = loc;
-            *(self.id_map.get_mut(&id).unwrap()) = last_loc;
-        };
 
         // Measure and collapse the state for this qubit.
-        let res = self.measure_impl(last_loc);
+        let res = self.measure_impl(loc);
 
-        // Remove the released ID from the mapping and cleanup the unused part of the state.
-        self.id_map.remove(&id);
+        // If the result of measurement was true then we must set the bit for this qubit in every key
+        // to zero to "reset" the qubit.
         if res {
             let qubit = self.id_map.len() as u64;
             self.state = self
                 .state
                 .drain()
-                .fold(FxHashMap::default(), |mut accum, (k, v)| {
-                    let mut new_k = k.clone();
-                    new_k.set_bit(qubit, !k.bit(qubit));
-                    accum.insert(new_k, v);
+                .fold(FxHashMap::default(), |mut accum, (mut k, v)| {
+                    k.set_bit(qubit, false);
+                    accum.insert(k, v);
                     accum
                 });
         }
@@ -113,9 +94,6 @@ impl QuantumSim {
 
     /// Prints the current state vector to standard output with integer labels for the states, skipping any
     /// states with zero amplitude.
-    /// # Panics
-    ///
-    /// This function panics if it is unable sort the state into qubit id order.
     pub(crate) fn dump(&mut self) {
         // Swap all the entries in the state to be ordered by qubit identifier. This makes
         // interpreting the state easier for external consumers that don't have access to the id map.
@@ -308,9 +286,12 @@ impl QuantumSim {
 
         // Normalize the new state using the accumulated scaling.
         let scaling = 1.0 / scaling_denominator.sqrt();
-        new_state.iter_mut().for_each(|(_, v)| *v *= scaling);
-
-        self.state = new_state;
+        for (k, v) in new_state.drain() {
+            let scaled_value = v * scaling;
+            if !scaled_value.is_nearly_zero() {
+                self.state.insert(k, scaled_value);
+            }
+        }
     }
 
     /// Swaps the mapped ids for the given qubits.


### PR DESCRIPTION
This adds a small, deterministic Grover's Search benchmark for the simulator backend. As part of this, it adds a new intrinsic, `__quantum__qis__assertzero__body`, that makes verifying probabilities easier than using the existing `__quantum__qis__assertmeasurementprobability__body`.

The changes also include some clean up of unexpected panic patterns as well as cleanup of qubit release to avoid unnecessary swaps (holdover from older implementation).