### PR TITLE
Cleaning up on backend code

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -68,7 +68,7 @@ unsafe fn map_paulis(
     if paulis_size != qubits_size {
         __quantum__rt__fail(__quantum__rt__string_create(
             CString::new("Pauli array and Qubit array must be the same size.")
-                .unwrap()
+                .expect("Unable to allocate memory for failure message string.")
                 .as_bytes_with_nul()
                 .as_ptr() as *mut i8,
         ));
@@ -567,8 +567,6 @@ pub extern "C" fn __quantum__qis__read_result__body(result: *mut c_void) -> bool
 }
 
 /// QIR API that measures a given qubit in the computational basis, returning a runtime managed result value.
-/// # Panics
-///
 #[no_mangle]
 pub extern "C" fn __quantum__qis__m__body(qubit: *mut c_void) -> *mut c_void {
     SIM_STATE.with(|sim_state| {
@@ -750,14 +748,15 @@ pub extern "C" fn __quantum__rt__qubit_allocate() -> *mut c_void {
 }
 
 /// QIR API for allocating the given number of qubits in the simulation, returning them as a runtime managed array.
-/// # Panics
-///
-/// This function will panic if the underlying platform has a pointer size that cannot be described in
-/// a `u32`.
 #[allow(clippy::cast_ptr_alignment)]
 #[no_mangle]
 pub extern "C" fn __quantum__rt__qubit_allocate_array(size: u64) -> *const QirArray {
-    let arr = __quantum__rt__array_create_1d(size_of::<usize>().try_into().unwrap(), size);
+    let arr = __quantum__rt__array_create_1d(
+        size_of::<usize>()
+            .try_into()
+            .expect("System pointer size too large to be described with u32"),
+        size,
+    );
     for index in 0..size {
         unsafe {
             let elem = __quantum__rt__array_get_element_ptr_1d(arr, index).cast::<*mut c_void>();
@@ -791,15 +790,12 @@ pub extern "C" fn __quantum__rt__qubit_release(qubit: *mut c_void) {
 }
 
 /// QIR API for getting the string interpretation of a qubit identifier.
-/// # Panics
-///
-/// This function will panic if it is unable to allocate the memory for the string.
 #[no_mangle]
 pub extern "C" fn __quantum__rt__qubit_to_string(qubit: *mut c_void) -> *const CString {
     unsafe {
         __quantum__rt__string_create(
             CString::new(format!("{}", qubit as usize))
-                .unwrap()
+                .expect("Unable to allocate memory for qubit string.")
                 .as_bytes_with_nul()
                 .as_ptr() as *mut i8,
         )

--- a/backend/src/simulator.rs
+++ b/backend/src/simulator.rs
@@ -33,9 +33,11 @@ impl QuantumSim {
     /// Creates a new sparse state quantum simulator object with empty initial state (no qubits allocated, no operations buffered).
     #[must_use]
     fn new() -> Self {
-        QuantumSim {
-            state: FxHashMap::default(),
+        let mut initial_state = FxHashMap::default();
+        initial_state.insert(BigUint::zero(), Complex64::one());
 
+        QuantumSim {
+            state: initial_state,
             id_map: FxHashMap::default(),
         }
     }
@@ -45,11 +47,6 @@ impl QuantumSim {
     /// if those identifiers are available.
     #[must_use]
     pub(crate) fn allocate(&mut self) -> usize {
-        if self.id_map.is_empty() {
-            // Add the intial value for the zero state.
-            self.state.insert(BigUint::zero(), Complex64::one());
-        }
-
         // Add the new entry into the FxHashMap at the first available sequential ID.
         let mut sorted_keys: Vec<&usize> = self.id_map.keys().collect();
         sorted_keys.sort();
@@ -72,40 +69,24 @@ impl QuantumSim {
     ///
     /// The function will panic if the given id does not correpsond to an allocated qubit.
     pub(crate) fn release(&mut self, id: usize) {
-        // Since it is easier to release a contiguous half of the state, find the qubit
-        // with the last location and swap that with the qubit to be released.
-        let n_qubits = self.id_map.len();
-        let loc = *self
+        let loc = self
             .id_map
-            .get(&id)
+            .remove(&id)
             .unwrap_or_else(|| panic!("Unable to find qubit with id {}.", id));
-        let last_loc = n_qubits - 1;
-        if last_loc != loc {
-            let last_id = *self
-                .id_map
-                .iter()
-                .find(|(_, &value)| value == last_loc)
-                .unwrap()
-                .0;
-            self.swap_qubit_state(loc, last_loc);
-            *(self.id_map.get_mut(&last_id).unwrap()) = loc;
-            *(self.id_map.get_mut(&id).unwrap()) = last_loc;
-        };
 
         // Measure and collapse the state for this qubit.
-        let res = self.measure_impl(last_loc);
+        let res = self.measure_impl(loc);
 
-        // Remove the released ID from the mapping and cleanup the unused part of the state.
-        self.id_map.remove(&id);
+        // If the result of measurement was true then we must set the bit for this qubit in every key
+        // to zero to "reset" the qubit.
         if res {
             let qubit = self.id_map.len() as u64;
             self.state = self
                 .state
                 .drain()
-                .fold(FxHashMap::default(), |mut accum, (k, v)| {
-                    let mut new_k = k.clone();
-                    new_k.set_bit(qubit, !k.bit(qubit));
-                    accum.insert(new_k, v);
+                .fold(FxHashMap::default(), |mut accum, (mut k, v)| {
+                    k.set_bit(qubit, false);
+                    accum.insert(k, v);
                     accum
                 });
         }
@@ -113,9 +94,6 @@ impl QuantumSim {
 
     /// Prints the current state vector to standard output with integer labels for the states, skipping any
     /// states with zero amplitude.
-    /// # Panics
-    ///
-    /// This function panics if it is unable sort the state into qubit id order.
     pub(crate) fn dump(&mut self) {
         // Swap all the entries in the state to be ordered by qubit identifier. This makes
         // interpreting the state easier for external consumers that don't have access to the id map.
@@ -308,9 +286,12 @@ impl QuantumSim {
 
         // Normalize the new state using the accumulated scaling.
         let scaling = 1.0 / scaling_denominator.sqrt();
-        new_state.iter_mut().for_each(|(_, v)| *v *= scaling);
-
-        self.state = new_state;
+        for (k, v) in new_state.drain() {
+            let scaled_value = v * scaling;
+            if !scaled_value.is_nearly_zero() {
+                self.state.insert(k, scaled_value);
+            }
+        }
     }
 
     /// Swaps the mapped ids for the given qubits.


### PR DESCRIPTION
This change cleans up the uses of `unwrap` in the backend code. It also removes some outdated code from the internal simulator implementation that streamlines initial set up and qubit release.