### PR TITLE
Add gate queuing and commuting for faster simulation

### DIFF
--- a/backend/src/exp.rs
+++ b/backend/src/exp.rs
@@ -24,7 +24,7 @@ use std::{
 use crate::{
     ensure_sufficient_qubits,
     nearly_zero::NearlyZero,
-    simulator::{QuantumSim, SparseState},
+    simulator::{FlushLevel, QuantumSim, SparseState},
     SIM_STATE,
 };
 
@@ -166,6 +166,9 @@ impl QuantumSim {
         theta: f64,
         targets: &[usize],
     ) {
+        self.flush_queue(ctls, FlushLevel::HRxRy);
+        self.flush_queue(targets, FlushLevel::HRxRy);
+
         let ctls: Vec<u64> = ctls
             .iter()
             .map(|c| {
@@ -372,7 +375,7 @@ mod tests {
 
         // If the rotations were performed correctly, the check qubit `paired` should
         // always be back in the ground state, and the whole state vector should be
-        // back to a single, zero state.
+        // back to a single zero state.
         assert!(!sim.joint_measure(&[paired]));
         assert_eq!(sim.state.len(), 1);
     }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -3,7 +3,11 @@
 
 #![deny(clippy::all, clippy::pedantic)]
 
-//! Module defining QIR compliant APIs for quantum simulation.
+//! # QIR compliant backend for quantum simulation.
+//! This libary builds on top of the `qir_stdlib` to implement a full backend for simulation of QIR
+//! programs. This includes a broad set of quantum intrinsic operations for sparse state simulation,
+//! based on the design from
+//! <a href="https://arxiv.org/abs/2105.01533">Leveraging state sparsity for more efficient quantum simulations</a>.
 
 pub mod result_bool;
 
@@ -754,7 +758,7 @@ pub extern "C" fn __quantum__rt__qubit_allocate_array(size: u64) -> *const QirAr
     let arr = __quantum__rt__array_create_1d(
         size_of::<usize>()
             .try_into()
-            .expect("System pointer size too large to be described with u32"),
+            .expect("System pointer size too large to be described with u32."),
         size,
     );
     for index in 0..size {

--- a/backend/src/simulator.rs
+++ b/backend/src/simulator.rs
@@ -6,9 +6,8 @@ use num_bigint::BigUint;
 use num_complex::Complex64;
 use num_traits::{One, Zero};
 use rand::Rng;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::f64::consts::FRAC_1_SQRT_2;
-use std::ops::ControlFlow;
 
 pub type SparseState = FxHashMap<BigUint, Complex64>;
 
@@ -20,6 +19,23 @@ pub(crate) struct QuantumSim {
 
     /// The mapping from qubit identifiers to internal state locations.
     pub(crate) id_map: FxHashMap<usize, usize>,
+
+    /// The bitmap that tracks whether a given qubit has an pending H operation queued on it.
+    h_flag: BigUint,
+
+    /// The map for tracking queued Pauli-X rotations by a given angle for a given qubit.
+    rx_queue: FxHashMap<usize, f64>,
+
+    /// The map for tracking queued Pauli-Y rotations by a given angle for a given qubit.
+    ry_queue: FxHashMap<usize, f64>,
+}
+
+/// Levels for flushing of queued gates.
+#[derive(Debug, Copy, Clone)]
+pub(crate) enum FlushLevel {
+    H,
+    HRx,
+    HRxRy,
 }
 
 impl Default for QuantumSim {
@@ -39,6 +55,9 @@ impl QuantumSim {
         QuantumSim {
             state: initial_state,
             id_map: FxHashMap::default(),
+            h_flag: BigUint::zero(),
+            rx_queue: FxHashMap::default(),
+            ry_queue: FxHashMap::default(),
         }
     }
 
@@ -69,6 +88,8 @@ impl QuantumSim {
     ///
     /// The function will panic if the given id does not correpsond to an allocated qubit.
     pub(crate) fn release(&mut self, id: usize) {
+        self.flush_queue(&[id], FlushLevel::HRxRy);
+
         let loc = self
             .id_map
             .remove(&id)
@@ -98,6 +119,8 @@ impl QuantumSim {
         // Swap all the entries in the state to be ordered by qubit identifier. This makes
         // interpreting the state easier for external consumers that don't have access to the id map.
         let mut sorted_keys: Vec<usize> = self.id_map.keys().copied().collect();
+        self.flush_queue(&sorted_keys, FlushLevel::HRxRy);
+
         sorted_keys.sort_unstable();
         sorted_keys.iter().enumerate().for_each(|(index, &key)| {
             if index != self.id_map[&key] {
@@ -144,25 +167,9 @@ impl QuantumSim {
     /// This function will panic if there are duplicate ids in the given list.
     #[must_use]
     pub(crate) fn joint_probability(&mut self, ids: &[usize]) -> f64 {
-        let mut sorted_targets = ids.to_vec();
-        sorted_targets.sort_unstable();
-        if let ControlFlow::Break(Some(duplicate)) =
-            sorted_targets.iter().try_fold(None, |last, current| {
-                last.map_or_else(
-                    || ControlFlow::Continue(Some(current)),
-                    |last| {
-                        if last == current {
-                            ControlFlow::Break(Some(current))
-                        } else {
-                            ControlFlow::Continue(Some(current))
-                        }
-                    },
-                )
-            })
-        {
-            panic!("Duplicate qubit id '{}' found in application.", duplicate);
-        }
+        self.flush_queue(ids, FlushLevel::HRxRy);
 
+        Self::check_for_duplicates(ids);
         let locs: Vec<usize> = ids
             .iter()
             .map(|id| {
@@ -182,6 +189,8 @@ impl QuantumSim {
     /// This funciton will panic if the given identifier does not correspond to an allocated qubit.
     #[must_use]
     pub(crate) fn measure(&mut self, id: usize) -> bool {
+        self.flush_queue(&[id], FlushLevel::HRxRy);
+
         self.measure_impl(
             *self
                 .id_map
@@ -208,25 +217,9 @@ impl QuantumSim {
     /// This function will panic if any of the given identifiers are duplicates.
     #[must_use]
     pub(crate) fn joint_measure(&mut self, ids: &[usize]) -> bool {
-        let mut sorted_targets = ids.to_vec();
-        sorted_targets.sort_unstable();
-        if let ControlFlow::Break(Some(duplicate)) =
-            sorted_targets.iter().try_fold(None, |last, current| {
-                last.map_or_else(
-                    || ControlFlow::Continue(Some(current)),
-                    |last| {
-                        if last == current {
-                            ControlFlow::Break(Some(current))
-                        } else {
-                            ControlFlow::Continue(Some(current))
-                        }
-                    },
-                )
-            })
-        {
-            panic!("Duplicate qubit id '{}' found in application.", duplicate);
-        }
+        self.flush_queue(ids, FlushLevel::HRxRy);
 
+        Self::check_for_duplicates(ids);
         let locs: Vec<usize> = ids
             .iter()
             .map(|id| {
@@ -296,6 +289,28 @@ impl QuantumSim {
 
     /// Swaps the mapped ids for the given qubits.
     pub(crate) fn swap_qubit_ids(&mut self, qubit1: usize, qubit2: usize) {
+        // Must also swap any queued operations.
+        let (h_val1, h_val2) = (
+            self.h_flag.bit(qubit1 as u64),
+            self.h_flag.bit(qubit2 as u64),
+        );
+        self.h_flag.set_bit(qubit1 as u64, h_val2);
+        self.h_flag.set_bit(qubit2 as u64, h_val1);
+
+        if let Some(rx_val) = self.rx_queue.get(&qubit1) {
+            self.rx_queue.insert(qubit2, *rx_val);
+        }
+        if let Some(rx_val) = self.rx_queue.get(&qubit1) {
+            self.rx_queue.insert(qubit1, *rx_val);
+        }
+
+        if let Some(ry_val) = self.ry_queue.get(&qubit1) {
+            self.ry_queue.insert(qubit2, *ry_val);
+        }
+        if let Some(ry_val) = self.ry_queue.get(&qubit1) {
+            self.ry_queue.insert(qubit1, *ry_val);
+        }
+
         let qubit1_mapped = *self
             .id_map
             .get(&qubit1)
@@ -313,6 +328,8 @@ impl QuantumSim {
         if qubit1 == qubit2 {
             return;
         }
+
+        self.flush_queue(&[qubit1, qubit2], FlushLevel::HRxRy);
 
         let (q1, q2) = (qubit1 as u64, qubit2 as u64);
 
@@ -333,9 +350,24 @@ impl QuantumSim {
             });
     }
 
+    pub(crate) fn check_for_duplicates(ids: &[usize]) {
+        let mut unique = FxHashSet::default();
+        for id in ids.iter() {
+            assert!(
+                unique.insert(id),
+                "Duplicate qubit id '{}' found in application.",
+                id
+            );
+        }
+    }
+
     /// Verifies that the given target and list of controls does not contain any duplicate entries, and returns
     /// those values mapped to internal identifiers and converted to `u64`.
     fn resolve_and_check_qubits(&self, target: usize, ctls: &[usize]) -> (u64, Vec<u64>) {
+        let mut ids = ctls.to_owned();
+        ids.push(target);
+        Self::check_for_duplicates(&ids);
+
         let target = *self
             .id_map
             .get(&target)
@@ -353,33 +385,45 @@ impl QuantumSim {
             })
             .collect();
 
-        let mut sorted_qubits = ctls.clone();
-        sorted_qubits.push(target);
-        sorted_qubits.sort_unstable();
-        if let ControlFlow::Break(Some(duplicate)) =
-            sorted_qubits.iter().try_fold(None, |last, current| {
-                last.map_or_else(
-                    || ControlFlow::Continue(Some(current)),
-                    |last| {
-                        if last == current {
-                            ControlFlow::Break(Some(current))
-                        } else {
-                            ControlFlow::Continue(Some(current))
-                        }
-                    },
-                )
-            })
-        {
-            panic!("Duplicate qubit id '{}' found in application.", duplicate);
-        }
-
         (target, ctls)
+    }
+
+    pub(crate) fn flush_queue(&mut self, qubits: &[usize], level: FlushLevel) {
+        for target in qubits {
+            if self.h_flag.bit(*target as u64) {
+                self.apply_mch(&[], *target);
+                self.h_flag.set_bit(*target as u64, false);
+            }
+            match level {
+                FlushLevel::H => (),
+                FlushLevel::HRx => self.flush_rx(*target),
+                FlushLevel::HRxRy => {
+                    self.flush_rx(*target);
+                    self.flush_ry(*target);
+                }
+            }
+        }
+    }
+
+    fn flush_rx(&mut self, target: usize) {
+        if let Some(theta) = self.rx_queue.get(&target) {
+            self.mcrotation(&[], *theta, target, false);
+            self.rx_queue.remove(&target);
+        }
+    }
+
+    fn flush_ry(&mut self, target: usize) {
+        if let Some(theta) = self.ry_queue.get(&target) {
+            self.mcrotation(&[], *theta, target, true);
+            self.ry_queue.remove(&target);
+        }
     }
 
     /// Utility for performing an in-place update of the state vector with the given target and controls.
     /// Here, "in-place" indicates that the given transformation operation can calulate a new entry in the
     /// state vector using only one entry of the state vector as input and does not need to refer to any
-    /// other entries. This covers the multicontrolled gates except for H, Rx, and Ry.
+    /// other entries. This covers the multicontrolled gates except for H, Rx, and Ry and notably keeps the
+    /// size of the state vector the same.
     fn controlled_gate<F>(&mut self, ctls: &[usize], target: usize, mut op: F)
     where
         F: FnMut((BigUint, Complex64), u64) -> (BigUint, Complex64),
@@ -410,12 +454,49 @@ impl QuantumSim {
 
     /// Single qubit X gate.
     pub(crate) fn x(&mut self, target: usize) {
-        self.controlled_gate(&[], target, Self::x_transform);
+        if let Some(entry) = self.ry_queue.get_mut(&target) {
+            // XY = -YX, so switch the sign on any queued Ry rotations.
+            *entry *= -1.0;
+        }
+        if self.h_flag.bit(target as u64) {
+            // XH = HZ, so execute a Z transformation if there is an H queued.
+            self.controlled_gate(&[], target, Self::z_transform);
+        } else {
+            self.controlled_gate(&[], target, Self::x_transform);
+        }
     }
 
     /// Multi-controlled X gate.
     pub(crate) fn mcx(&mut self, ctls: &[usize], target: usize) {
-        self.controlled_gate(ctls, target, Self::x_transform);
+        if ctls.is_empty() {
+            self.x(target);
+            return;
+        }
+
+        if ctls.len() > 1
+            || self.ry_queue.contains_key(&ctls[0])
+            || self.rx_queue.contains_key(&ctls[0])
+            || (self.h_flag.bit(ctls[0] as u64) && !self.h_flag.bit(target as u64))
+        {
+            self.flush_queue(ctls, FlushLevel::HRxRy);
+        }
+
+        if self.ry_queue.contains_key(&target) {
+            self.flush_queue(&[target], FlushLevel::HRxRy);
+        }
+
+        if self.h_flag.bit(target as u64) {
+            if ctls.len() == 1 && self.h_flag.bit(ctls[0] as u64) {
+                // An H on both target and single control means we can perform a CNOT with the control
+                // and target switched.
+                self.controlled_gate(&[target], ctls[0], Self::x_transform);
+            } else {
+                // XH = HZ, so perform a mulit-controlled Z here.
+                self.controlled_gate(ctls, target, Self::z_transform);
+            }
+        } else {
+            self.controlled_gate(ctls, target, Self::x_transform);
+        }
     }
 
     /// Performs the Pauli-Y transformation on a single state.
@@ -434,11 +515,35 @@ impl QuantumSim {
 
     /// Single qubit Y gate.
     pub(crate) fn y(&mut self, target: usize) {
+        if let Some(entry) = self.rx_queue.get_mut(&target) {
+            // XY = -YX, so flip the sign on any queued Rx rotation.
+            *entry *= -1.0;
+        }
+
         self.controlled_gate(&[], target, Self::y_transform);
     }
 
     /// Multi-controlled Y gate.
     pub(crate) fn mcy(&mut self, ctls: &[usize], target: usize) {
+        if ctls.is_empty() {
+            self.y(target);
+            return;
+        }
+
+        self.flush_queue(ctls, FlushLevel::HRxRy);
+
+        if self.rx_queue.contains_key(&target) {
+            self.flush_queue(&[target], FlushLevel::HRx);
+        }
+
+        if self.h_flag.bit(target as u64) {
+            // HY = -YH, so add a phase to one of the controls.
+            let (target, ctls) = ctls
+                .split_first()
+                .expect("Controls list cannot be empty here.");
+            self.controlled_gate(ctls, *target, Self::z_transform);
+        }
+
         self.controlled_gate(ctls, target, Self::y_transform);
     }
 
@@ -471,12 +576,71 @@ impl QuantumSim {
 
     /// Single qubit Z gate.
     pub(crate) fn z(&mut self, target: usize) {
-        self.controlled_gate(&[], target, Self::z_transform);
+        if let Some(entry) = self.ry_queue.get_mut(&target) {
+            // ZY = -YZ, so flip the sign on any queued Ry rotations.
+            *entry *= -1.0;
+        }
+
+        if let Some(entry) = self.rx_queue.get_mut(&target) {
+            // ZX = -XZ, so flip the sign on any queued Rx rotations.
+            *entry *= -1.0;
+        }
+
+        if self.h_flag.bit(target as u64) {
+            // HZ = XH, so execute an X if an H is queued.
+            self.controlled_gate(&[], target, Self::x_transform);
+        } else {
+            self.controlled_gate(&[], target, Self::z_transform);
+        }
     }
 
     /// Multi-controlled Z gate.
     pub(crate) fn mcz(&mut self, ctls: &[usize], target: usize) {
-        self.controlled_gate(ctls, target, Self::z_transform);
+        if ctls.is_empty() {
+            self.z(target);
+            return;
+        }
+
+        // Count up the instances of queued H and Rx/Ry on controls and target, treating rotations as 2.
+        let count = ctls.iter().fold(0, |accum, c| {
+            accum
+                + i32::from(self.h_flag.bit(*c as u64))
+                + if self.rx_queue.contains_key(c) || self.ry_queue.contains_key(c) {
+                    2
+                } else {
+                    0
+                }
+        }) + i32::from(self.h_flag.bit(target as u64))
+            + if self.rx_queue.contains_key(&target) || self.ry_queue.contains_key(&target) {
+                2
+            } else {
+                0
+            };
+
+        if count == 1 {
+            // Only when count is exactly one can we optimize, meaning there is exactly one H on either
+            // the target or one control. Create a new controls list and target where the target is whichever
+            // qubit has the H queued.
+            let (ctls, target): (Vec<usize>, usize) =
+                if let Some(h_ctl) = ctls.iter().find(|c| self.h_flag.bit(**c as u64)) {
+                    // The H is queued on one control, so create a new controls list that swaps that control for the original target.
+                    (
+                        ctls.iter()
+                            .map(|c| if c == h_ctl { target } else { *c })
+                            .collect(),
+                        *h_ctl,
+                    )
+                } else {
+                    // The H is queued on the target, so use the original values.
+                    (ctls.to_owned(), target)
+                };
+            // With a single H queued, treat the multi-controlled Z as a multi-controlled X.
+            self.controlled_gate(&ctls, target, Self::x_transform);
+        } else {
+            self.flush_queue(ctls, FlushLevel::HRxRy);
+            self.flush_queue(&[target], FlushLevel::HRxRy);
+            self.controlled_gate(ctls, target, Self::z_transform);
+        }
     }
 
     /// Performs the S transformation on a single state.
@@ -486,11 +650,14 @@ impl QuantumSim {
 
     /// Single qubit S gate.
     pub(crate) fn s(&mut self, target: usize) {
+        self.flush_queue(&[target], FlushLevel::HRxRy);
         self.controlled_gate(&[], target, Self::s_transform);
     }
 
     /// Multi-controlled S gate.
     pub(crate) fn mcs(&mut self, ctls: &[usize], target: usize) {
+        self.flush_queue(ctls, FlushLevel::HRxRy);
+        self.flush_queue(&[target], FlushLevel::HRxRy);
         self.controlled_gate(ctls, target, Self::s_transform);
     }
 
@@ -501,11 +668,14 @@ impl QuantumSim {
 
     /// Single qubit Adjoint S Gate.
     pub(crate) fn sadj(&mut self, target: usize) {
+        self.flush_queue(&[target], FlushLevel::HRxRy);
         self.controlled_gate(&[], target, Self::sadj_transform);
     }
 
     /// Multi-controlled Adjoint S gate.
     pub(crate) fn mcsadj(&mut self, ctls: &[usize], target: usize) {
+        self.flush_queue(ctls, FlushLevel::HRxRy);
+        self.flush_queue(&[target], FlushLevel::HRxRy);
         self.controlled_gate(ctls, target, Self::sadj_transform);
     }
 
@@ -520,11 +690,14 @@ impl QuantumSim {
 
     /// Single qubit T gate.
     pub(crate) fn t(&mut self, target: usize) {
+        self.flush_queue(&[target], FlushLevel::HRxRy);
         self.controlled_gate(&[], target, Self::t_transform);
     }
 
     /// Multi-controlled T gate.
     pub(crate) fn mct(&mut self, ctls: &[usize], target: usize) {
+        self.flush_queue(ctls, FlushLevel::HRxRy);
+        self.flush_queue(&[target], FlushLevel::HRxRy);
         self.controlled_gate(ctls, target, Self::t_transform);
     }
 
@@ -539,11 +712,14 @@ impl QuantumSim {
 
     /// Single qubit Adjoint T gate.
     pub(crate) fn tadj(&mut self, target: usize) {
+        self.flush_queue(&[target], FlushLevel::HRxRy);
         self.controlled_gate(&[], target, Self::tadj_transform);
     }
 
     /// Multi-controlled Adjoint T gate.
     pub(crate) fn mctadj(&mut self, ctls: &[usize], target: usize) {
+        self.flush_queue(ctls, FlushLevel::HRxRy);
+        self.flush_queue(&[target], FlushLevel::HRxRy);
         self.controlled_gate(ctls, target, Self::tadj_transform);
     }
 
@@ -563,6 +739,7 @@ impl QuantumSim {
 
     /// Single qubit Rz gate.
     pub(crate) fn rz(&mut self, theta: f64, target: usize) {
+        self.flush_queue(&[target], FlushLevel::HRxRy);
         self.controlled_gate(&[], target, |(index, val), target| {
             Self::rz_transform((index, val), theta, target)
         });
@@ -570,6 +747,8 @@ impl QuantumSim {
 
     /// Multi-controlled Rz gate.
     pub(crate) fn mcrz(&mut self, ctls: &[usize], theta: f64, target: usize) {
+        self.flush_queue(ctls, FlushLevel::HRxRy);
+        self.flush_queue(&[target], FlushLevel::HRxRy);
         self.controlled_gate(ctls, target, |(index, val), target| {
             Self::rz_transform((index, val), theta, target)
         });
@@ -577,11 +756,34 @@ impl QuantumSim {
 
     /// Single qubit H gate.
     pub(crate) fn h(&mut self, target: usize) {
-        self.mch(&[], target);
+        if let Some(entry) = self.ry_queue.get_mut(&target) {
+            // YH = -HY, so flip the sign on any queued Ry rotations.
+            *entry *= -1.0;
+        }
+
+        if self.rx_queue.contains_key(&target) {
+            // Can't commute well with queued Rx, so flush those ops.
+            self.flush_queue(&[target], FlushLevel::HRx);
+        }
+
+        self.h_flag
+            .set_bit(target as u64, !self.h_flag.bit(target as u64));
     }
 
     /// Multi-controlled H gate.
     pub(crate) fn mch(&mut self, ctls: &[usize], target: usize) {
+        self.flush_queue(ctls, FlushLevel::HRxRy);
+        if self.ry_queue.contains_key(&target) || self.rx_queue.contains_key(&target) {
+            self.flush_queue(&[target], FlushLevel::HRxRy);
+        }
+
+        self.apply_mch(ctls, target);
+    }
+
+    /// Apply the full state transformation corresponding to the multi-controlled H gate. Note that
+    /// this can increase the size of the state vector by introducing new non-zero states
+    /// or decrease the size by bringing some states to zero.
+    fn apply_mch(&mut self, ctls: &[usize], target: usize) {
         let (target, ctls) = self.resolve_and_check_qubits(target, ctls);
 
         // This operation cannot be done in-place so create a new empty state vector to populate.
@@ -636,7 +838,8 @@ impl QuantumSim {
     }
 
     /// Performs a rotation in the non-computational basis, which cannot be done in-place. This
-    /// corresponds to an Rx or Ry depending on the requested sign flip.
+    /// corresponds to an Rx or Ry depending on the requested sign flip, and notably can increase or
+    /// decrease the size of the state vector.
     fn mcrotation(&mut self, ctls: &[usize], theta: f64, target: usize, sign_flip: bool) {
         // Calculate the matrix entries for the rotation by the given angle, respecting the sign flip.
         let m00 = Complex64::new(f64::cos(theta / 2.0), 0.0);
@@ -703,21 +906,52 @@ impl QuantumSim {
 
     /// Single qubit Rx gate.
     pub(crate) fn rx(&mut self, theta: f64, target: usize) {
-        self.mcrotation(&[], theta, target, false);
+        self.flush_queue(&[target], FlushLevel::HRxRy);
+        if let Some(entry) = self.rx_queue.get_mut(&target) {
+            *entry += theta;
+            if entry.is_nearly_zero() {
+                self.rx_queue.remove(&target);
+            }
+        } else {
+            self.rx_queue.insert(target, theta);
+        }
     }
 
     /// Multi-controlled Rx gate.
     pub(crate) fn mcrx(&mut self, ctls: &[usize], theta: f64, target: usize) {
+        self.flush_queue(ctls, FlushLevel::HRxRy);
+
+        if self.ry_queue.contains_key(&target) {
+            self.flush_queue(&[target], FlushLevel::HRxRy);
+        } else if self.h_flag.bit(target as u64) {
+            self.flush_queue(&[target], FlushLevel::H);
+        }
+
         self.mcrotation(ctls, theta, target, false);
     }
 
     /// Single qubit Ry gate.
     pub(crate) fn ry(&mut self, theta: f64, target: usize) {
-        self.mcrotation(&[], theta, target, true);
+        if let Some(entry) = self.ry_queue.get_mut(&target) {
+            *entry += theta;
+            if entry.is_nearly_zero() {
+                self.ry_queue.remove(&target);
+            }
+        } else {
+            self.ry_queue.insert(target, theta);
+        }
     }
 
     /// Multi-controlled Ry gate.
     pub(crate) fn mcry(&mut self, ctls: &[usize], theta: f64, target: usize) {
+        self.flush_queue(ctls, FlushLevel::HRxRy);
+
+        if self.rx_queue.contains_key(&target) {
+            self.flush_queue(&[target], FlushLevel::HRx);
+        } else if self.h_flag.bit(target as u64) {
+            self.flush_queue(&[target], FlushLevel::H);
+        }
+
         self.mcrotation(ctls, theta, target, true);
     }
 }
@@ -851,9 +1085,9 @@ mod tests {
         sim.release(q0);
     }
 
-    /// Test arbitrary controls, which should extend the applied unitary matrix.
+    /// Test multiple controls.
     #[test]
-    fn test_arbitrary_controls() {
+    fn test_multiple_controls() {
         let mut sim = QuantumSim::default();
         let q0 = sim.allocate();
         let q1 = sim.allocate();
@@ -958,6 +1192,8 @@ mod tests {
         assert!(sim.joint_probability(&[ctl]).is_nearly_zero());
 
         // Sparse state vector should have one entry for |0⟩.
+        // Dump the state first to force a flush of any queued operations.
+        sim.dump();
         assert_eq!(sim.state.len(), 1);
     }
 

--- a/backend/src/simulator.rs
+++ b/backend/src/simulator.rs
@@ -564,6 +564,8 @@ impl QuantumSim {
 
     /// Multi-controlled phase rotation ("G" gate).
     pub(crate) fn mcphase(&mut self, ctls: &[usize], phase: Complex64, target: usize) {
+        self.flush_queue(ctls, FlushLevel::HRxRy);
+        self.flush_queue(&[target], FlushLevel::HRxRy);
         self.controlled_gate(ctls, target, |(index, val), target| {
             Self::phase_transform(phase, (index, val), target)
         });


### PR DESCRIPTION
This change updates the sparse state simulation to incorporate queuing of `H`, `Rx`, and `Ry` gates along with some logic for commuting operations through these gates. This allows these three operations, which can change the size of the state vector and reduce sparsity, to be delayed and sometimes skipped. While the logic for queuing introduces some overhead to each gate operation, the gain in speed and memory footprint for certain common gate sequences involving `H`, `Rx`, and `Ry` can be very significant. For example, the individual gate benchmarks for other gates showed about an 8% regression (from 3.4 to 3.6 microseconds) while the three queued gates showed a nearly 70% improvement in performance (from 17 to 5 microseconds), and even the small Grover's Search benchmark showed more than 20% improvement (from 17 to 13 microseconds). Improvements are more pronounced for larger algorithms that primarily operate on a subset of the qubits.

This change includes an update to the testing logic to interleave queued operations between the operations under test in order to verify equivalence of a queued and commuted operation with its non-queued, non-commuted adjoint.

This change also adds top level documentation for the `qir_backend` crate that points to the paper published on sparse state simulation, https://arxiv.org/abs/2105.01533.