### PR TITLE
Update qir-stdlib build script for include files

### DIFF
--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Microsoft"]
 edition = "2021"
 license = "MIT"
+links = "qir-stdlib"
 
 [dependencies]
 num-bigint = { version = "0.4.3", default-features = false }

--- a/stdlib/build.rs
+++ b/stdlib/build.rs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::env;
 use std::path::PathBuf;
 use std::process::Command;
+use std::{env, fs};
 
 use llvm_tools::LlvmTools;
 
@@ -54,6 +54,16 @@ fn main() -> Result<(), String> {
 
     println!("cargo:rustc-link-lib=static=bridge-rt");
     println!("cargo:rustc-link-search=native={}", out_dir.display());
+
+    // Copy the include files for non-Rust consumers and make them available for downstream compilation.
+    let include_dir = out_dir.join("include");
+    fs::create_dir_all(&include_dir)
+        .map_err(|err| format!("Error creating 'include' directory: {}", err))?;
+    fs::copy("include/qir_stdlib.def", include_dir.join("qir_stdlib.def"))
+        .map_err(|err| format!("Error copying 'qir_stdlib.def' file: {}", err))?;
+    fs::copy("include/qir_stdlib.h", include_dir.join("qir_stdlib.h"))
+        .map_err(|err| format!("Error copying 'qir_stdlib.h' file: {}", err))?;
+    println!("cargo:include={}", include_dir.display());
 
     Ok(())
 }


### PR DESCRIPTION
This updates the logic in the build.rs for qir-stdlib to copy the include filse (one C-style header and one Windows .def file) into the output directory, as well as set a cargo metadata key that lets downstream consumers find those files more easily.