### PR TITLE
Fix out of order allocate/release

### DIFF
--- a/backend/src/simulator.rs
+++ b/backend/src/simulator.rs
@@ -1064,7 +1064,7 @@ mod tests {
         // Release out of order.
         sim.release(3);
 
-        // Remaining qubits should all be in zero state except 4.
+        // Remaining qubits should all still be in one.
         assert_eq!(sim.state.len(), 1);
         assert!(!sim.joint_probability(&[0]).is_nearly_zero());
         assert!(!sim.joint_probability(&[1]).is_nearly_zero());


### PR DESCRIPTION
This fixes a bug in the backend that would clear the wrong qubit location when doing an out of order release. It also addresses allocation after out of order release and ensures the right location is used and zero. A new test verifies this case.