### PR TITLE
Fix endianess for BigInt support

### DIFF
--- a/stdlib/src/bigints.rs
+++ b/stdlib/src/bigints.rs
@@ -15,19 +15,19 @@ pub unsafe extern "C" fn __quantum__rt__bigint_create_array(
     size: u32,
     input: *const u8,
 ) -> *const BigInt {
-    Rc::into_raw(Rc::new(BigInt::from_signed_bytes_be(
+    Rc::into_raw(Rc::new(BigInt::from_signed_bytes_le(
         std::slice::from_raw_parts(input, size as usize),
     )))
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn __quantum__rt__bigint_get_data(input: *const BigInt) -> *const u8 {
-    ManuallyDrop::new((*input).to_signed_bytes_be()).as_ptr()
+    ManuallyDrop::new((*input).to_signed_bytes_le()).as_ptr()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn __quantum__rt__bigint_get_length(input: *const BigInt) -> u32 {
-    let size = (*input).to_signed_bytes_be().len();
+    let size = (*input).to_signed_bytes_le().len();
     size.try_into()
         .expect("Length of bigint representation too large for 32-bit integer.")
 }
@@ -181,11 +181,11 @@ mod tests {
 
     #[test]
     fn test_bigint_create_from_array() {
-        let bytes = 42_i64.to_be_bytes();
+        let bytes = 9_223_372_036_854_775_807_i64.to_le_bytes();
         unsafe {
             let bigint_1 =
                 __quantum__rt__bigint_create_array(bytes.len().try_into().unwrap(), bytes.as_ptr());
-            assert_eq!(*bigint_1, (42).try_into().unwrap());
+            assert_eq!(*bigint_1, (9_223_372_036_854_775_807_i64).try_into().unwrap());
             __quantum__rt__bigint_update_reference_count(bigint_1, -1);
         }
     }

--- a/stdlib/src/bigints.rs
+++ b/stdlib/src/bigints.rs
@@ -185,7 +185,10 @@ mod tests {
         unsafe {
             let bigint_1 =
                 __quantum__rt__bigint_create_array(bytes.len().try_into().unwrap(), bytes.as_ptr());
-            assert_eq!(*bigint_1, (9_223_372_036_854_775_807_i64).try_into().unwrap());
+            assert_eq!(
+                *bigint_1,
+                (9_223_372_036_854_775_807_i64).try_into().unwrap()
+            );
             __quantum__rt__bigint_update_reference_count(bigint_1, -1);
         }
     }

--- a/stdlib/src/strings.rs
+++ b/stdlib/src/strings.rs
@@ -119,7 +119,7 @@ mod tests {
 
     use super::*;
     use crate::bigints::{
-        __quantum__rt__bigint_create_i64, __quantum__rt__bigint_update_reference_count,
+        __quantum__rt__bigint_create_i64, __quantum__rt__bigint_update_reference_count, __quantum__rt__bigint_create_array,
     };
 
     #[test]
@@ -289,8 +289,7 @@ mod tests {
 
     #[test]
     fn test_to_string() {
-        let input0 = 42;
-        let str0 = __quantum__rt__int_to_string(input0);
+        let str0 = __quantum__rt__int_to_string(42_i64);
         unsafe {
             assert_eq!(
                 CStr::from_ptr(__quantum__rt__string_get_data(str0))
@@ -299,8 +298,7 @@ mod tests {
                 "42"
             );
         }
-        let input1 = 4.2;
-        let str1 = __quantum__rt__double_to_string(input1);
+        let str1 = __quantum__rt__double_to_string(4.2_f64);
         unsafe {
             assert_eq!(
                 CStr::from_ptr(__quantum__rt__string_get_data(str1))
@@ -309,8 +307,7 @@ mod tests {
                 "4.2"
             );
         }
-        let input1_1 = 4.0;
-        let str1_1 = __quantum__rt__double_to_string(input1_1);
+        let str1_1 = __quantum__rt__double_to_string(4.0_f64);
         unsafe {
             assert_eq!(
                 CStr::from_ptr(__quantum__rt__string_get_data(str1_1))
@@ -319,8 +316,7 @@ mod tests {
                 "4.0"
             );
         }
-        let input1_2 = 0.1;
-        let str1_2 = __quantum__rt__double_to_string(input1_2);
+        let str1_2 = __quantum__rt__double_to_string(0.1_f64);
         unsafe {
             assert_eq!(
                 CStr::from_ptr(__quantum__rt__string_get_data(str1_2))
@@ -329,8 +325,7 @@ mod tests {
                 "0.1"
             );
         }
-        let input1_3 = 0.100_000_000_01;
-        let str1_3 = __quantum__rt__double_to_string(input1_3);
+        let str1_3 = __quantum__rt__double_to_string(0.100_000_000_01_f64);
         unsafe {
             assert_eq!(
                 CStr::from_ptr(__quantum__rt__string_get_data(str1_3))
@@ -339,8 +334,7 @@ mod tests {
                 "0.10000000001"
             );
         }
-        let input2 = false;
-        let str2 = __quantum__rt__bool_to_string(input2);
+        let str2 = __quantum__rt__bool_to_string(false);
         unsafe {
             assert_eq!(
                 CStr::from_ptr(__quantum__rt__string_get_data(str2))
@@ -349,8 +343,7 @@ mod tests {
                 "false"
             );
         }
-        let input3 = Pauli::Z;
-        let str3 = __quantum__rt__pauli_to_string(input3);
+        let str3 = __quantum__rt__pauli_to_string(Pauli::Z);
         unsafe {
             assert_eq!(
                 CStr::from_ptr(__quantum__rt__string_get_data(str3))
@@ -368,7 +361,18 @@ mod tests {
                     .unwrap(),
                 "400002"
             );
-
+            __quantum__rt__string_update_reference_count(str4, -1);
+        }
+        unsafe {
+            let bytes = [0x18, 0xFC, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xF3, 0x01];
+            let input5 = __quantum__rt__bigint_create_array(bytes.len().try_into().unwrap(), bytes.as_ptr());
+            let str5 = __quantum__rt__bigint_to_string(input5);
+            assert_eq!(
+                CStr::from_ptr(__quantum__rt__string_get_data(str5))
+                    .to_str()
+                    .unwrap(),
+                "9223372036854775807000"
+            );
             __quantum__rt__string_update_reference_count(str0, -1);
             __quantum__rt__string_update_reference_count(str1, -1);
             __quantum__rt__string_update_reference_count(str1_1, -1);
@@ -376,8 +380,8 @@ mod tests {
             __quantum__rt__string_update_reference_count(str1_3, -1);
             __quantum__rt__string_update_reference_count(str2, -1);
             __quantum__rt__string_update_reference_count(str3, -1);
-            __quantum__rt__string_update_reference_count(str4, -1);
             __quantum__rt__bigint_update_reference_count(input4, -1);
+            __quantum__rt__bigint_update_reference_count(input5, -1);
         }
     }
 }

--- a/stdlib/src/strings.rs
+++ b/stdlib/src/strings.rs
@@ -119,7 +119,8 @@ mod tests {
 
     use super::*;
     use crate::bigints::{
-        __quantum__rt__bigint_create_i64, __quantum__rt__bigint_update_reference_count, __quantum__rt__bigint_create_array,
+        __quantum__rt__bigint_create_array, __quantum__rt__bigint_create_i64,
+        __quantum__rt__bigint_update_reference_count,
     };
 
     #[test]
@@ -365,7 +366,8 @@ mod tests {
         }
         unsafe {
             let bytes = [0x18, 0xFC, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xF3, 0x01];
-            let input5 = __quantum__rt__bigint_create_array(bytes.len().try_into().unwrap(), bytes.as_ptr());
+            let input5 =
+                __quantum__rt__bigint_create_array(bytes.len().try_into().unwrap(), bytes.as_ptr());
             let str5 = __quantum__rt__bigint_to_string(input5);
             assert_eq!(
                 CStr::from_ptr(__quantum__rt__string_get_data(str5))


### PR DESCRIPTION
The qir_stdlib exposes APIs for constructing BigInt values from byte arrays, and should be accepting little endian byte arrays. Previous implementation incorrectly expected big endian byte arrays, causing values to be calculated incorrectly. This change expands tests to cover larger input cases and confirm representation as string.