### PR TITLE
Adds a feature to control inclusion of range support

### DIFF
--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -18,4 +18,4 @@ crate-type = ["staticlib", "rlib"]
 
 [features]
 default = []
-skip-range-support = []
+disable-range-support = []

--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -15,3 +15,7 @@ llvm-tools = "0.1.1"
 
 [lib]
 crate-type = ["staticlib", "rlib"]
+
+[features]
+default = []
+skip-range-support = []

--- a/stdlib/build.rs
+++ b/stdlib/build.rs
@@ -8,52 +8,55 @@ use std::{env, fs};
 use llvm_tools::LlvmTools;
 
 fn main() -> Result<(), String> {
-    // Compile the LLVM IR bridge file. Requires the llvm-tools-preview component.
-    // This is only needed for range support, and this entire build.rs can be dropped when that functionality is
-    // no longer needed.
     let out_dir = env::var_os("OUT_DIR")
         .map(PathBuf::from)
         .ok_or_else(|| "Environment variable OUT_DIR not defined.".to_string())?;
 
-    let llvm_tools = LlvmTools::new().map_err(|err| {
+    if !cfg!(feature = "skip-range-support") {
+        // Compile the LLVM IR bridge file. Requires the llvm-tools-preview component.
+        // This is only needed for range support, and this entire build.rs can be dropped when that functionality is
+        // no longer needed.
+
+        let llvm_tools = LlvmTools::new().map_err(|err| {
         format!(
             "Failed to locate llvm tools: {:?}. Is the llvm-tools-preview component installed? Try using `rustup component add llvm-tools-preview`.",
             err
         )
     })?;
 
-    let llc_path = llvm_tools
-        .tool(llvm_tools::exe("llc").to_string().as_str())
-        .ok_or_else(|| "Failed to find llc.".to_string())?;
-    let llvm_ar_path = llvm_tools
-        .tool(llvm_tools::exe("llvm-ar").to_string().as_str())
-        .ok_or_else(|| "Failed to find llvm-ar.".to_string())?;
-    let lib_name = if cfg!(target_os = "windows") {
-        "bridge-rt.lib"
-    } else {
-        "libbridge-rt.a"
-    };
+        let llc_path = llvm_tools
+            .tool(llvm_tools::exe("llc").to_string().as_str())
+            .ok_or_else(|| "Failed to find llc.".to_string())?;
+        let llvm_ar_path = llvm_tools
+            .tool(llvm_tools::exe("llvm-ar").to_string().as_str())
+            .ok_or_else(|| "Failed to find llvm-ar.".to_string())?;
+        let lib_name = if cfg!(target_os = "windows") {
+            "bridge-rt.lib"
+        } else {
+            "libbridge-rt.a"
+        };
 
-    Command::new(llc_path)
-        .args(&[
-            "--filetype=obj",
-            "./src/bridge-rt.ll",
-            "-o",
-            &format!("{}/bridge-rt.o", out_dir.display()),
-        ])
-        .status()
-        .map_err(|err| format!("llc failed: {}.", err))?;
-    Command::new(llvm_ar_path)
-        .args(&[
-            "-r",
-            &format!("{}/{}", out_dir.display(), lib_name),
-            &format!("{}/bridge-rt.o", out_dir.display()),
-        ])
-        .status()
-        .map_err(|err| format!("llvm-ar failed: {}.", err))?;
+        Command::new(llc_path)
+            .args(&[
+                "--filetype=obj",
+                "./src/bridge-rt.ll",
+                "-o",
+                &format!("{}/bridge-rt.o", out_dir.display()),
+            ])
+            .status()
+            .map_err(|err| format!("llc failed: {}.", err))?;
+        Command::new(llvm_ar_path)
+            .args(&[
+                "-r",
+                &format!("{}/{}", out_dir.display(), lib_name),
+                &format!("{}/bridge-rt.o", out_dir.display()),
+            ])
+            .status()
+            .map_err(|err| format!("llvm-ar failed: {}.", err))?;
 
-    println!("cargo:rustc-link-lib=static=bridge-rt");
-    println!("cargo:rustc-link-search=native={}", out_dir.display());
+        println!("cargo:rustc-link-lib=static=bridge-rt");
+        println!("cargo:rustc-link-search=native={}", out_dir.display());
+    }
 
     // Copy the include files for non-Rust consumers and make them available for downstream compilation.
     let include_dir = out_dir.join("include");

--- a/stdlib/build.rs
+++ b/stdlib/build.rs
@@ -12,7 +12,7 @@ fn main() -> Result<(), String> {
         .map(PathBuf::from)
         .ok_or_else(|| "Environment variable OUT_DIR not defined.".to_string())?;
 
-    if !cfg!(feature = "skip-range-support") {
+    if !cfg!(feature = "disable-range-support") {
         // Compile the LLVM IR bridge file. Requires the llvm-tools-preview component.
         // This is only needed for range support, and this entire build.rs can be dropped when that functionality is
         // no longer needed.


### PR DESCRIPTION
This change adds a feature to allow a downstream consumer to control the inclusion of the range support compiled from raw LLVM IR. This allows for skipping it in contexts where it is not needed and/or incompatible, such as wasm.