### PR TITLE
Simplify LLVM dependency versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ on:
 env:
   RUSTFLAGS: -Dwarnings
   CARGO_INCREMENTAL: 0
-  LLVM_FEATURE: llvm14-0
 
 jobs:
   fmt:
@@ -33,10 +32,10 @@ jobs:
         run: cargo fmt -v --all -- --check
 
       - name: cargo clippy
-        run: cargo clippy -vv --all-targets --features ${{ env.LLVM_FEATURE }}
+        run: cargo clippy -vv --all-targets
 
       - name: cargo doc
-        run: cargo doc -vv --all --no-deps --features ${{ env.LLVM_FEATURE }}
+        run: cargo doc -vv --all --no-deps
 
       - name: Publish Docs as Artifacts
         uses: actions/upload-artifact@v2
@@ -58,7 +57,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: cargo bench
-        run: cargo bench --workspace --features ${{ env.LLVM_FEATURE }}
+        run: cargo bench --workspace
 
   build:
     name: Build
@@ -73,9 +72,9 @@ jobs:
         run: rustup show
       - uses: Swatinem/rust-cache@v2
       - name: Build
-        run: cargo build -vv --release --features ${{ env.LLVM_FEATURE }}
+        run: cargo build -vv --release
       - name: Test
-        run: cargo test -vv --release --features ${{ env.LLVM_FEATURE }} -- --nocapture
+        run: cargo test -vv --release -- --nocapture
 
   nightly:
     name: Build Nightly
@@ -94,9 +93,9 @@ jobs:
           components: rustfmt, clippy, llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
       - name: Build Nightly
-        run: cargo build -vv --release --features ${{ env.LLVM_FEATURE }}
+        run: cargo build -vv --release
       - name: Test Nightly
-        run: cargo test -vv --release --features ${{ env.LLVM_FEATURE }} -- --nocapture
+        run: cargo test -vv --release -- --nocapture
 
   release:
     name: Release
@@ -105,18 +104,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {
-              os: "ubuntu-20.04",
-              arch: "amd64",
-            }
-          - {
-              os: "windows-2019",
-              arch: "amd64",
-            }
-          - {
-              os: "macos-11",
-              arch: "amd64",
-            }
+          - { os: "ubuntu-20.04", arch: "amd64" }
+          - { os: "windows-2019", arch: "amd64" }
+          - { os: "macos-11", arch: "amd64" }
     steps:
       - uses: actions/checkout@v3
       - name: Setup rust toolchain
@@ -129,9 +119,9 @@ jobs:
           directory: ${{ github.workspace }}/target/llvm
           arch: ${{ matrix.config.arch }}
       - name: Build
-        run: cargo build -vv --release --features ${{ env.LLVM_FEATURE }}
+        run: cargo build -vv --release
       - name: Test
-        run: cargo test -vv --release --features ${{ env.LLVM_FEATURE }} -- --nocapture
+        run: cargo test -vv --release -- --nocapture
       - name: Artifacts executable
         uses: actions/upload-artifact@v3
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,10 +265,7 @@ dependencies = [
  "either",
  "inkwell_internals",
  "libc",
- "llvm-sys 110.0.4",
- "llvm-sys 120.2.5",
- "llvm-sys 130.0.5",
- "llvm-sys 140.0.3",
+ "llvm-sys",
  "once_cell",
  "parking_lot",
 ]
@@ -321,45 +318,6 @@ checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "llvm-sys"
-version = "110.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abad6f4c44960941ebd7d26b97719f9b8dba379f971b48de919d03462527c3d"
-dependencies = [
- "cc",
- "lazy_static",
- "libc",
- "regex",
- "semver 0.11.0",
-]
-
-[[package]]
-name = "llvm-sys"
-version = "120.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1c9655eec036faf512507746ce70765bda72ed98e52b4328f0d7b93e970c6d8"
-dependencies = [
- "cc",
- "lazy_static",
- "libc",
- "regex",
- "semver 0.11.0",
-]
-
-[[package]]
-name = "llvm-sys"
-version = "130.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e12061782e78da1f5e5f7f758dcdda04bc97af90e8e55bef5f56f1162759ffc"
-dependencies = [
- "cc",
- "lazy_static",
- "libc",
- "regex",
- "semver 0.11.0",
-]
-
-[[package]]
-name = "llvm-sys"
 version = "140.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b9eda9cc6f86672152125b1e112d66ab8797b7917fb202e2faee912caa76413"
@@ -368,7 +326,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "regex",
- "semver 1.0.14",
+ "semver",
 ]
 
 [[package]]
@@ -521,16 +479,6 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-sys",
-]
-
-[[package]]
-name = "pest"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a528564cc62c19a7acac4d81e01f39e53e25e17b934878f4c6d25cc2836e62f8"
-dependencies = [
- "thiserror",
- "ucd-trie",
 ]
 
 [[package]]
@@ -738,27 +686,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "serde"
@@ -821,26 +751,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
-name = "thiserror"
-version = "1.0.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,12 +759,6 @@ dependencies = [
  "serde",
  "serde_json",
 ]
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "unicode-ident"

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -8,14 +8,7 @@ license = "MIT"
 git = "https://github.com/TheDan64/inkwell"
 branch = "master"
 default-features = false
-features = []
+features = ["llvm14-0"]
 
 [dependencies.qir-backend]
 path = "../backend"
-
-[features]
-default = []
-llvm11-0 = ["inkwell/llvm11-0"]
-llvm12-0 = ["inkwell/llvm12-0"]
-llvm13-0 = ["inkwell/llvm13-0"]
-llvm14-0 = ["inkwell/llvm14-0"]


### PR DESCRIPTION
This change updates the feature flags for runner to pin to currently supported LLVM version 14. Feature flags for other versions of LLVM are no longer included, so an explicity selection of LLVM version is not required to build the runner.