### PR TITLE
Add shots, use explicit cmdline args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -110,9 +110,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "bitflags",
- "clap_lex",
+ "clap_lex 0.2.4",
  "indexmap",
  "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
+dependencies = [
+ "bitflags",
+ "clap_lex 0.3.1",
+ "is-terminal",
+ "strsim",
+ "termcolor",
 ]
 
 [[package]]
@@ -120,6 +133,15 @@ name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
 dependencies = [
  "os_str_bytes",
 ]
@@ -134,7 +156,7 @@ dependencies = [
  "atty",
  "cast",
  "ciborium",
- "clap",
+ "clap 3.2.23",
  "criterion-plot",
  "itertools",
  "lazy_static",
@@ -210,6 +232,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,6 +291,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,6 +330,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -315,6 +389,12 @@ name = "libc"
 version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "llvm-sys"
@@ -436,7 +516,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -543,6 +623,7 @@ dependencies = [
 name = "qir-runner"
 version = "0.1.0"
 dependencies = [
+ "clap 4.1.4",
  "inkwell",
  "qir-backend",
 ]
@@ -664,6 +745,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustix"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,6 +823,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,6 +844,15 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "textwrap"

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -10,5 +10,6 @@ branch = "master"
 default-features = false
 features = ["llvm14-0"]
 
-[dependencies.qir-backend]
-path = "../backend"
+[dependencies]
+qir-backend = { path = "../backend" }
+clap = "4.1.4"

--- a/runner/src/lib.rs
+++ b/runner/src/lib.rs
@@ -33,7 +33,7 @@ use std::{collections::HashMap, ffi::OsStr, path::Path};
 pub fn run_file(
     path: impl AsRef<Path>,
     entry_point: Option<&str>,
-    shots: i64,
+    shots: u32,
 ) -> Result<(), String> {
     let context = Context::create();
     let module = load_file(path, &context)?;
@@ -46,14 +46,14 @@ pub fn run_file(
 /// - `bytes` does not contain a valid bitcode module
 /// - `entry_point` is not found in the QIR
 /// - Entry point has parameters or a non-void return type.
-pub fn run_bitcode(bytes: &[u8], entry_point: Option<&str>, shots: i64) -> Result<(), String> {
+pub fn run_bitcode(bytes: &[u8], entry_point: Option<&str>, shots: u32) -> Result<(), String> {
     let context = Context::create();
     let buffer = MemoryBuffer::create_from_memory_range(bytes, "");
     let module = Module::parse_bitcode_from_buffer(&buffer, &context).map_err(|e| e.to_string())?;
     run_module(&module, entry_point, shots)
 }
 
-fn run_module(module: &Module, entry_point: Option<&str>, shots: i64) -> Result<(), String> {
+fn run_module(module: &Module, entry_point: Option<&str>, shots: u32) -> Result<(), String> {
     module
         .verify()
         .map_err(|e| format!("Failed to verify module: {}", e.to_string()))?;

--- a/runner/src/lib.rs
+++ b/runner/src/lib.rs
@@ -30,10 +30,14 @@ use std::{collections::HashMap, ffi::OsStr, path::Path};
 /// - `filename` does not have either a .ll or .bc as an extension
 /// - `entry_point` is not found in the QIR
 /// - Entry point has parameters or a non-void return type.
-pub fn run_file(path: impl AsRef<Path>, entry_point: Option<&str>) -> Result<(), String> {
+pub fn run_file(
+    path: impl AsRef<Path>,
+    entry_point: Option<&str>,
+    shots: i64,
+) -> Result<(), String> {
     let context = Context::create();
     let module = load_file(path, &context)?;
-    run_module(&module, entry_point)
+    run_module(&module, entry_point, shots)
 }
 
 /// # Errors
@@ -42,14 +46,14 @@ pub fn run_file(path: impl AsRef<Path>, entry_point: Option<&str>) -> Result<(),
 /// - `bytes` does not contain a valid bitcode module
 /// - `entry_point` is not found in the QIR
 /// - Entry point has parameters or a non-void return type.
-pub fn run_bitcode(bytes: &[u8], entry_point: Option<&str>) -> Result<(), String> {
+pub fn run_bitcode(bytes: &[u8], entry_point: Option<&str>, shots: i64) -> Result<(), String> {
     let context = Context::create();
     let buffer = MemoryBuffer::create_from_memory_range(bytes, "");
     let module = Module::parse_bitcode_from_buffer(&buffer, &context).map_err(|e| e.to_string())?;
-    run_module(&module, entry_point)
+    run_module(&module, entry_point, shots)
 }
 
-fn run_module(module: &Module, entry_point: Option<&str>) -> Result<(), String> {
+fn run_module(module: &Module, entry_point: Option<&str>, shots: i64) -> Result<(), String> {
     module
         .verify()
         .map_err(|e| format!("Failed to verify module: {}", e.to_string()))?;
@@ -93,8 +97,7 @@ fn run_module(module: &Module, entry_point: Option<&str>) -> Result<(), String> 
         })
         .collect();
 
-    // This loop is a placeholder where shots will be defined
-    for _ in 1..=1 {
+    for _ in 1..=shots {
         println!("START");
         for attr in &attrs {
             print!("METADATA\t{}", attr.0);

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -15,7 +15,7 @@ fn main() -> Result<(), String> {
             .required(true),
         arg!(-e --entrypoint <NAME> "Name of the entry point function to execute"),
         arg!(-s --shots <NUM> "The number of times to repeat the execution of the chosen entry point in the program")
-            .value_parser(value_parser!(i64))
+            .value_parser(value_parser!(u32))
             .default_value("1")]);
 
     let matches = cmd.try_get_matches().map_err(|e| e.to_string());
@@ -29,7 +29,7 @@ fn main() -> Result<(), String> {
             matches
                 .get_one::<String>("entrypoint")
                 .map(std::string::String::as_str),
-            *matches.get_one::<i64>("shots").unwrap(),
+            *matches.get_one::<u32>("shots").unwrap(),
         ),
     }
 }

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -3,22 +3,33 @@
 
 #![deny(clippy::all, clippy::pedantic)]
 
-use std::env;
+use std::path::PathBuf;
+
+use clap::{arg, value_parser, Command};
+// use std::env;
 
 fn main() -> Result<(), String> {
-    let args: Vec<String> = env::args().collect();
-    if args.len() == 1 {
-        println!("OVERVIEW: Virtual execution environment for QIR programs");
-        println!();
-        println!("USAGE: qir-runner <ll/bc filename> [entry point function]");
-        Ok(())
-    } else {
-        let path = &args[1];
-        let name = if args.len() > 2 {
-            Some(args[2].as_str())
-        } else {
-            None
-        };
-        qir_runner::run_file(path, name)
+    let cmd = Command::new("qir-runner").args(&[
+        arg!(-f --file <PATH> "(Required) Path to the QIR file to run")
+            .value_parser(value_parser!(PathBuf))
+            .required(true),
+        arg!(-e --entrypoint <NAME> "Name of the entry point function to execute"),
+        arg!(-s --shots <NUM> "The number of times to repeat the execution of the chosen entry point in the program")
+            .value_parser(value_parser!(i64))
+            .default_value("1")]);
+
+    let matches = cmd.try_get_matches().map_err(|e| e.to_string());
+    match matches {
+        Err(e) => {
+            print!("{}", e);
+            Ok(())
+        }
+        Ok(matches) => qir_runner::run_file(
+            matches.get_one::<PathBuf>("file").unwrap(),
+            matches
+                .get_one::<String>("entrypoint")
+                .map(std::string::String::as_str),
+            *matches.get_one::<i64>("shots").unwrap(),
+        ),
     }
 }

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), String> {
     let matches = cmd.try_get_matches().map_err(|e| e.to_string());
     match matches {
         Err(e) => {
-            print!("{}", e);
+            eprint!("{}", e);
             Ok(())
         }
         Ok(matches) => qir_runner::run_file(

--- a/runner/tests/tests.rs
+++ b/runner/tests/tests.rs
@@ -10,7 +10,7 @@ use qir_runner::{run_bitcode, run_file};
 #[test]
 fn test_choi_jamiolkowski_isomorphism() -> Result<(), String> {
     let bitcode = include_bytes!("resources/cji.bc");
-    run_bitcode(bitcode, None)
+    run_bitcode(bitcode, None, 1)
 }
 
 // This test confirms selection of a particular named entry point from a file with two entry points
@@ -19,7 +19,7 @@ fn test_choi_jamiolkowski_isomorphism() -> Result<(), String> {
 #[test]
 fn test_full_qir_simple() -> Result<(), String> {
     let bitcode = include_bytes!("resources/full-qir.bc");
-    run_bitcode(bitcode, Some("QIR_App_Test__Simple"))
+    run_bitcode(bitcode, Some("QIR_App_Test__Simple"), 1)
 }
 
 // This test confirms selection of the other named entry point from a file with two entry points
@@ -30,7 +30,7 @@ fn test_full_qir_simple() -> Result<(), String> {
 #[test]
 fn test_full_qir_other() -> Result<(), String> {
     let bitcode = include_bytes!("resources/full-qir.bc");
-    run_bitcode(bitcode, Some("QIR_App_Test__Other"))
+    run_bitcode(bitcode, Some("QIR_App_Test__Other"), 1)
 }
 
 // This tests a simple Bernstein-Vazirani algorithm looking for the encoded pattern |110⟩ in a qubit array.
@@ -40,7 +40,7 @@ fn test_full_qir_other() -> Result<(), String> {
 #[test]
 fn test_bernstein_vazirani() -> Result<(), String> {
     let bitcode = include_bytes!("resources/bv.bc");
-    run_bitcode(bitcode, None)
+    run_bitcode(bitcode, None, 1)
 }
 
 // This tests support for range operations `__quantum__rt__array_slice_1d` and `__quantum__rt__range_to_string`
@@ -52,7 +52,7 @@ fn test_bernstein_vazirani() -> Result<(), String> {
 #[test]
 fn test_ranges() -> Result<(), String> {
     let bitcode = include_bytes!("resources/ranges.bc");
-    run_bitcode(bitcode, None)
+    run_bitcode(bitcode, None, 1)
 }
 
 // This test runs a sample Shor's algorithm for integer factorization. It makes use of quantum execution
@@ -61,19 +61,19 @@ fn test_ranges() -> Result<(), String> {
 #[test]
 fn test_shor() -> Result<(), String> {
     let bitcode = include_bytes!("resources/shor.bc");
-    run_bitcode(bitcode, None)
+    run_bitcode(bitcode, None, 1)
 }
 
 #[test]
 fn run_file_errors_on_invalid_ext() {
-    let result = run_file("/some/bad/path", None);
+    let result = run_file("/some/bad/path", None, 1);
     assert!(result.is_err());
     assert_eq!("Unsupported file extension 'None'.", result.unwrap_err());
 }
 
 #[test]
 fn run_file_errors_on_missing_file() {
-    let result = run_file("/some/bad/path.ll", None);
+    let result = run_file("/some/bad/path.ll", None, 1);
     assert!(result.is_err());
     assert_eq!(
         "no such file or directory",
@@ -84,7 +84,7 @@ fn run_file_errors_on_missing_file() {
 #[test]
 fn run_file_errors_on_missing_binding() {
     let bitcode = include_bytes!("resources/missing-intrinsic.bc");
-    let result = run_bitcode(bitcode, None);
+    let result = run_bitcode(bitcode, None, 1);
     assert!(result.is_err());
     assert_eq!(
         "failed to link some declared functions: __quantum__qis__mycustomintrinsic__body",
@@ -95,7 +95,7 @@ fn run_file_errors_on_missing_binding() {
 #[test]
 fn mixed_output_recording_calls_fail() {
     let bitcode = include_bytes!("resources/mixed_output.bc");
-    let result = run_bitcode(bitcode, None);
+    let result = run_bitcode(bitcode, None, 1);
     assert!(result.is_err());
     assert_eq!(
         "function '__quantum__rt__array_record_output' has mismatched parameters: expected 2, found 1",


### PR DESCRIPTION
This change adds the ability to specify a number of shots for execution when running the QIR program, which should increase speed and usability vs invoking the exe each time.

This also changes the way cmdline arguments are processed, requiring the `-f` or `--file` cmdline parameter when specifying the file to run, and `-e` or `--entrypoint` for the optional entry point name. This is a breaking change vs the positional argument pattern qir-runner used before.

This partially addresses #30 but does not introduce an rng seed parameter.