### PR TITLE
Add rngseed cmdline parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,20 @@ Intermediate Representation (QIR)](https://github.com/qir-alliance/qir-spec) pro
   This package provides an API or CLI tool to execute QIR.
 - [**stdlib**](stdlib)
   This package implements the QIR standard runtime library
+
+## Command Line Usage
+
+```
+Usage: qir-runner [OPTIONS] --file <PATH>
+
+Options:
+  -f, --file <PATH>        (Required) Path to the QIR file to run
+  -e, --entrypoint <NAME>  Name of the entry point function to execute
+  -s, --shots <NUM>        The number of times to repeat the execution of the chosen entry point in the program [default: 1]
+  -r, --rngseed <NUM>      The value to use when seeding the random number generator used for quantum simulation
+  -h, --help               Print help
+```
+
 ## Documentation
 
 API documentation is available at [https://qir-alliance.github.io/qir-runner](https://qir-alliance.github.io/qir-runner).

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -55,6 +55,11 @@ thread_local! {
     });
 }
 
+/// Sets the seed for the pseudo-random number generator used during measurements.
+pub fn set_rng_seed(seed: u64) {
+    simulator::set_rng_seed(seed);
+}
+
 /// Initializes the execution environment.
 #[no_mangle]
 pub extern "C" fn __quantum__rt__initialize(_: *mut c_char) {

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -16,7 +16,9 @@ fn main() -> Result<(), String> {
         arg!(-e --entrypoint <NAME> "Name of the entry point function to execute"),
         arg!(-s --shots <NUM> "The number of times to repeat the execution of the chosen entry point in the program")
             .value_parser(value_parser!(u32))
-            .default_value("1")]);
+            .default_value("1"),
+        arg!(-r --rngseed <NUM> "The value to use when seeding the random number generator used for quantum simulation")
+            .value_parser(value_parser!(u64))]);
 
     let matches = cmd.try_get_matches().map_err(|e| e.to_string());
     match matches {
@@ -24,12 +26,18 @@ fn main() -> Result<(), String> {
             eprint!("{}", e);
             Ok(())
         }
-        Ok(matches) => qir_runner::run_file(
-            matches.get_one::<PathBuf>("file").unwrap(),
-            matches
-                .get_one::<String>("entrypoint")
-                .map(std::string::String::as_str),
-            *matches.get_one::<u32>("shots").unwrap(),
-        ),
+        Ok(matches) => {
+            if let Ok(Some(seed)) = matches.try_get_one::<u64>("rngseed") {
+                qir_backend::set_rng_seed(*seed);
+            }
+
+            qir_runner::run_file(
+                matches.get_one::<PathBuf>("file").unwrap(),
+                matches
+                    .get_one::<String>("entrypoint")
+                    .map(std::string::String::as_str),
+                *matches.get_one::<u32>("shots").unwrap(),
+            )
+        }
     }
 }


### PR DESCRIPTION
This change adds the `--rngseed` or `-r` cmdline parameter to the runner that can allow callers to seed the thread-local pseudo-random number generator used during quantum simulation. This can be handy for testing purposes by increasing predictability. Note that the seed is set outside of the shot loop, so that multiple shots should still be distinct but the sequence of results for the shots should always be the same for the same seed.

Also note that this only sets the seed used for quantum randomness. The classical randomness provided by `__quantum__qis__drawrandomint__body` and `__quantum__qis__drawrandomdouble__body` in the standard library do not use the seeded rng and remain non-deterministically random.

Along with #31, this resolves #30.