### PR TITLE
Add Rust `qubit_is_zero` function

### DIFF
--- a/backend/benches/grover.rs
+++ b/backend/benches/grover.rs
@@ -54,8 +54,8 @@ pub fn grover(c: &mut Criterion) {
             // and assert both qubits are back in the |0⟩ state.
             __quantum__qis__z__body(1 as *mut c_void);
             __quantum__qis__x__body(1 as *mut c_void);
-            __quantum__qis__assertzero__body(std::ptr::null_mut());
-            __quantum__qis__assertzero__body(1 as *mut c_void);
+            assert!(qubit_is_zero(std::ptr::null_mut()));
+            assert!(qubit_is_zero(1 as *mut c_void));
         })
     });
 }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -637,6 +637,20 @@ pub unsafe extern "C" fn __quantum__qis__measure__body(
     })
 }
 
+/// QIR API for checking internal simulator state and returning true if the given qubit is in the |0⟩ state.
+#[no_mangle]
+pub extern "C" fn __quantum__qis__checkzero__body(qubit: *mut c_void) -> bool {
+    SIM_STATE.with(|sim_state| {
+        let state = &mut *sim_state.borrow_mut();
+        ensure_sufficient_qubits(&mut state.sim, qubit as usize, &mut state.max_qubit_id);
+
+        state
+            .sim
+            .joint_probability(&[qubit as usize])
+            .is_nearly_zero()
+    })
+}
+
 /// QIR API for checking internal simulator state and verifying the given qubit is in the |0⟩ state.
 #[no_mangle]
 pub extern "C" fn __quantum__qis__assertzero__body(qubit: *mut c_void) {


### PR DESCRIPTION
This adds a new Rust function that can perform a check of the quantum state for a given qubit without triggering a terminating assert. This makes it easier to use the function in situations where peeking at the backend state is needed. The change also removes the unused `__quantum__qis__assertzero__body` function in favor of later conversation about expanding the QIR API.

This also adds a simple test for `qubit_is_zero`.