### PR TITLE
Rework LLVM-IR range support feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,6 +626,7 @@ dependencies = [
  "clap 4.1.4",
  "inkwell",
  "qir-backend",
+ "qir-stdlib",
 ]
 
 [[package]]

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -11,6 +11,6 @@ default-features = false
 features = ["llvm14-0"]
 
 [dependencies]
-qir-stdlib = { path = "../stdlib", features = ["ir-range-support"] }
+qir-stdlib = { path = "../stdlib", features = ["range-support"] }
 qir-backend = { path = "../backend" }
 clap = "4.1.4"

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -11,5 +11,6 @@ default-features = false
 features = ["llvm14-0"]
 
 [dependencies]
+qir-stdlib = { path = "../stdlib", features = ["ir-range-support"] }
 qir-backend = { path = "../backend" }
 clap = "4.1.4"

--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -11,11 +11,11 @@ num-bigint = { version = "0.4.3", default-features = false }
 rand = "0.8.5"
 
 [build-dependencies]
-llvm-tools = "0.1.1"
+llvm-tools = { version = "0.1.1", optional = true}
 
 [lib]
 crate-type = ["staticlib", "rlib"]
 
 [features]
 default = []
-disable-range-support = []
+ir-range-support = ["llvm-tools"]

--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -18,4 +18,4 @@ crate-type = ["staticlib", "rlib"]
 
 [features]
 default = []
-ir-range-support = ["llvm-tools"]
+range-support = ["llvm-tools"]

--- a/stdlib/build.rs
+++ b/stdlib/build.rs
@@ -9,7 +9,7 @@ fn main() -> Result<(), String> {
         .map(PathBuf::from)
         .ok_or_else(|| "Environment variable OUT_DIR not defined.".to_string())?;
 
-    #[cfg(feature = "ir-range-support")]
+    #[cfg(feature = "range-support")]
     {
         // Compile the LLVM IR bridge file. Requires the llvm-tools-preview component.
         // This is only needed for range support, and this entire build.rs can be dropped when that functionality is


### PR DESCRIPTION
This change refactors the feature flag for LLVM IR based range support to be an additive flag rather than a disabling flag, and keeps it out of the default list. That allows qir-runner (or even other consumers of qir-backend) to update the feature flag list to add it back in, and if they do not, correctly skips bulding the llvm-tools build dependency.