### PR TITLE
Dump sim state as JSON

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -864,16 +864,17 @@ pub extern "C" fn __quantum__rt__qubit_to_string(qubit: *mut c_void) -> *const C
     }
 }
 
-/// API for viewing the current global result and quantum state for the simulator.
-#[no_mangle]
-pub extern "C" fn dump_state() {
+/// Rust API for viewing the current global result and quantum state for the simulator.
+pub fn dump_state(output: &mut impl std::io::Write) {
     SIM_STATE.with(|sim_state| {
         let mut state = sim_state.borrow_mut();
 
         if !state.res.is_empty() {
-            println!("Global Results: {}", state.res);
+            output
+                .write_fmt(format_args!("Global Results: {}\n", state.res))
+                .expect("Unable to write to output");
         }
-        state.sim.dump();
+        state.sim.dump(output);
     });
 }
 
@@ -883,12 +884,14 @@ pub extern "C" fn __quantum__qis__dumpmachine__body(location: *mut c_void) {
     if !location.is_null() {
         unimplemented!("Dump to location is not implemented.")
     }
-    dump_state();
+    dump_state(&mut std::io::stdout());
 }
 
 #[cfg(test)]
 mod tests {
-    use std::ffi::c_void;
+    use std::{ffi::c_void, ptr::null_mut};
+
+    use crate::__quantum__qis__dumpmachine__body;
 
     use crate::qubit_is_zero;
 
@@ -897,7 +900,7 @@ mod tests {
         __quantum__qis__mz__body, __quantum__qis__read_result__body, __quantum__qis__x__body,
         __quantum__rt__qubit_allocate, __quantum__rt__qubit_allocate_array,
         __quantum__rt__qubit_release, __quantum__rt__qubit_release_array,
-        __quantum__rt__result_equal, __quantum__rt__result_get_one, dump_state,
+        __quantum__rt__result_equal, __quantum__rt__result_get_one,
     };
     use qir_stdlib::arrays::__quantum__rt__array_get_element_ptr_1d;
 
@@ -915,7 +918,7 @@ mod tests {
         __quantum__qis__mz__body(q0, r0);
         assert!(!__quantum__qis__read_result__body(r0));
         assert!(!__quantum__qis__read_result__body(3 as *mut c_void));
-        dump_state();
+        __quantum__qis__dumpmachine__body(null_mut());
     }
 
     #[allow(clippy::cast_ptr_alignment)]
@@ -928,14 +931,14 @@ mod tests {
         let r1 = __quantum__qis__m__body(q1);
         let r2 = __quantum__qis__m__body(q2);
         assert!(__quantum__rt__result_equal(r1, r2));
-        dump_state();
+        __quantum__qis__dumpmachine__body(null_mut());
         __quantum__rt__qubit_release(q2);
         __quantum__rt__qubit_release(q1);
         let qs = __quantum__rt__qubit_allocate_array(4);
         unsafe {
             let q_elem = __quantum__rt__array_get_element_ptr_1d(qs, 3).cast::<*mut c_void>();
             __quantum__qis__x__body(*q_elem);
-            dump_state();
+            __quantum__qis__dumpmachine__body(null_mut());
             let r = __quantum__qis__m__body(*q_elem);
             assert!(__quantum__rt__result_equal(
                 r,

--- a/backend/src/matrix_testing.rs
+++ b/backend/src/matrix_testing.rs
@@ -413,7 +413,7 @@ mod tests {
 
         // Sparse state vector should have one entry for |0⟩.
         // Dump the state first to force a flush of any queued operations.
-        sim.dump();
+        sim.dump(&mut std::io::stdout());
         assert_eq!(sim.state.len(), 1);
     }
 

--- a/backend/src/simulator.rs
+++ b/backend/src/simulator.rs
@@ -130,7 +130,7 @@ impl QuantumSim {
 
     /// Prints the current state vector to standard output with integer labels for the states, skipping any
     /// states with zero amplitude.
-    pub(crate) fn dump(&mut self) {
+    pub(crate) fn dump(&mut self, output: &mut impl std::io::Write) {
         // Swap all the entries in the state to be ordered by qubit identifier. This makes
         // interpreting the state easier for external consumers that don't have access to the id map.
         let mut sorted_keys: Vec<usize> = self.id_map.keys().copied().collect();
@@ -151,27 +151,43 @@ impl QuantumSim {
             }
         });
 
-        self.dump_impl(false);
+        self.dump_impl(false, output);
     }
 
     /// Utility function that performs the actual output of state (and optionally map) to screen. Can
     /// be called internally from other functions to aid in debugging and does not perform any modification
     /// of the internal structures.
-    fn dump_impl(&self, print_id_map: bool) {
+    fn dump_impl(&self, print_id_map: bool, output: &mut impl std::io::Write) {
         if print_id_map {
-            println!("MAP: {:?}", self.id_map);
+            output
+                .write_fmt(format_args!("MAP: {:?}\n", self.id_map))
+                .expect("Unable to write to output");
         };
-        print!("STATE: [ ");
+        output
+            .write_fmt(format_args!("{{ "))
+            .expect("Unable to write to output");
         let mut sorted_keys = self.state.keys().collect::<Vec<_>>();
         sorted_keys.sort_unstable();
-        for key in sorted_keys {
-            print!(
-                "|{}\u{27e9}: {}, ",
-                key,
-                self.state.get(key).map_or_else(Complex64::zero, |v| *v)
-            );
+        let (last_key, most_keys) = sorted_keys.split_last().unwrap();
+        for key in most_keys {
+            let val = self.state.get(key).map_or_else(Complex64::zero, |v| *v);
+            output
+                .write_fmt(format_args!(
+                    "\"|{}\u{27e9}\": [{}, {}], ",
+                    key, val.re, val.im
+                ))
+                .expect("Unable to write to output");
         }
-        println!("]");
+        let last_val = self
+            .state
+            .get(last_key)
+            .map_or_else(Complex64::zero, |v| *v);
+        output
+            .write_fmt(format_args!(
+                "\"|{}\u{27e9}\": [{}, {}] }}\n",
+                last_key, last_val.re, last_val.im
+            ))
+            .expect("Unable to write to output");
     }
 
     /// Checks the probability of parity measurement in the computational basis for the given set of
@@ -1326,7 +1342,7 @@ mod tests {
 
             // Sparse state vector should have one entry for |0⟩.
             // Dump the state first to force a flush of any queued operations.
-            sim.dump();
+            sim.dump(&mut std::io::stdout());
             assert_eq!(sim.state.len(), 1);
         }
     }


### PR DESCRIPTION
This change updates the simulator state dump to output in a JSON compatible format. It also updates the non-QIR API to be a Rust pub fn that accepts a writer for better compatibility in scenarios without stdout.