### PR TITLE
Add Windows rustflags

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+# -Ccontrol-flow-guard: Enable Control Flow Guard (needed for OneBranch's post-build analysis).
+# -Ctarget-feature=+crt-static: Statically link the CRT (required to link the spectre-mitigated CRT).
+# -Clink-args=/DYNAMICBASE /CETCOMPAT: Enable "shadow stack" (https://docs.microsoft.com/en-us/cpp/build/reference/cetcompat)
+[target.'cfg(target_os = "windows")']
+rustflags = ["-Ccontrol-flow-guard", "-Ctarget-feature=+crt-static", "-Clink-args=/DYNAMICBASE /CETCOMPAT"]


### PR DESCRIPTION
This change adds a cargo config.toml with Windows specific rustflags to enable control flow guard, static C runtime, and shadow stack link args. See comments in the config.toml file.