### PR TITLE
Make tests more robust to state corner cases

### DIFF
--- a/backend/src/exp.rs
+++ b/backend/src/exp.rs
@@ -376,7 +376,9 @@ mod tests {
         // If the rotations were performed correctly, the check qubit `paired` should
         // always be back in the ground state, and the whole state vector should be
         // back to a single zero state.
-        assert!(!sim.joint_measure(&[paired]));
+        assert!(sim.joint_probability(&[paired]).is_nearly_zero());
+        assert!(sim.joint_probability(&[target]).is_nearly_zero());
+        assert!(sim.joint_probability(&[control]).is_nearly_zero());
         assert_eq!(sim.state.len(), 1);
     }
 }

--- a/backend/src/matrix_testing.rs
+++ b/backend/src/matrix_testing.rs
@@ -403,13 +403,16 @@ mod tests {
         reference(&mut sim, &qs);
 
         // Undo the entanglement.
-        for q in qs {
-            sim.mcx(&[ctl], q);
+        for q in &qs {
+            sim.mcx(&[ctl], *q);
         }
         sim.h(ctl);
 
-        // We know the operations are equal if the control is left in the zero state.
+        // We know the operations are equal if the qubits are left in the zero state.
         assert!(sim.joint_probability(&[ctl]).is_nearly_zero());
+        for q in qs {
+            assert!(sim.joint_probability(&[q]).is_nearly_zero());
+        }
 
         // Sparse state vector should have one entry for |0⟩.
         // Dump the state first to force a flush of any queued operations.

--- a/backend/src/simulator.rs
+++ b/backend/src/simulator.rs
@@ -1315,13 +1315,16 @@ mod tests {
             let _ = sim.joint_probability(&qs);
 
             // Undo the entanglement.
-            for q in qs {
-                sim.mcx(&[ctl], q);
+            for q in &qs {
+                sim.mcx(&[ctl], *q);
             }
             sim.h(ctl);
 
-            // We know the operations are equal if the control is left in the zero state.
+            // We know the operations are equal if the qubits are left in the zero state.
             assert!(sim.joint_probability(&[ctl]).is_nearly_zero());
+            for q in qs {
+                assert!(sim.joint_probability(&[q]).is_nearly_zero());
+            }
 
             // Sparse state vector should have one entry for |0⟩.
             // Dump the state first to force a flush of any queued operations.


### PR DESCRIPTION
This updates the tests for the simulator to include a check of all the qubits operated on to avoid corner case where certain operations can be considered equivalent when they actually are not.