### PR TITLE
Update benches to compare against main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,18 @@ jobs:
         run: rustup show
       - uses: Swatinem/rust-cache@v2
 
-      - name: cargo bench
-        run: cargo bench --workspace
+      - name: cargo bench changes
+        run: cargo bench --workspace -- --save-baseline changes
+
+      - uses: actions/checkout@v3
+        with:
+          ref: 'main'
+
+      - name: cargo bench main
+        run: cargo bench --workspace -- --save-baseline main
+
+      - name: bench comparison
+        run: cargo bench -- --load-baseline changes --baseline main
 
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,8 @@ jobs:
       - name: cargo bench changes
         run: cargo bench --package qir-backend -- --save-baseline changes
 
-      - uses: actions/checkout@v3
-        with:
-          ref: 'main'
+      - name: checkout main
+        run: git checkout origin/main
 
       - name: cargo bench main
         run: cargo bench --package qir-backend -- --save-baseline main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,9 @@ jobs:
       - name: cargo bench changes
         run: cargo bench --package qir-backend -- --save-baseline changes
 
-      - name: checkout main
-        run: git checkout origin/main
+      - uses: actions/checkout@v3
+        with:
+          ref: 'main'
 
       - name: cargo bench main
         run: cargo bench --package qir-backend -- --save-baseline main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,14 +57,14 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: cargo bench changes
-        run: cargo bench --workspace -- --save-baseline changes
+        run: cargo bench --package qir-backend -- --save-baseline changes
 
       - uses: actions/checkout@v3
         with:
           ref: 'main'
 
       - name: cargo bench main
-        run: cargo bench --workspace -- --save-baseline main
+        run: cargo bench --package qir-backend -- --save-baseline main
 
       - name: bench comparison
         run: cargo bench -- --load-baseline changes --baseline main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,8 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          ref: 'main'
+          ref: main
+          clean: false
 
       - name: cargo bench main
         run: cargo bench --package qir-backend -- --save-baseline main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v1
-        with:
-          version: "14.0"
       - name: Setup rust toolchain
         run: rustup show
       - uses: Swatinem/rust-cache@v2
@@ -67,7 +63,7 @@ jobs:
         run: cargo bench --package qir-backend -- --save-baseline main
 
       - name: bench comparison
-        run: cargo bench -- --load-baseline changes --baseline main
+        run: cargo bench --package qir-backend -- --load-baseline changes --baseline main
 
   build:
     name: Build


### PR DESCRIPTION
This change updates the benches section of the CI workflow to include comparison against main. Note that benches do not succeed or fail based on any specific perf boundaries, it just provoides more info in the logs. Rather than having just the latest perf values, it will show the latest as compared to the perf recorded from main.