### PR TITLE
Add support for `capture_quantum_state`

### DIFF
--- a/backend/src/simulator.rs
+++ b/backend/src/simulator.rs
@@ -69,6 +69,31 @@ impl QuantumSim {
         }
     }
 
+    #[must_use]
+    pub(crate) fn get_state(&mut self) -> Vec<(BigUint, Complex64)> {
+        // Swap all the entries in the state to be ordered by qubit identifier. This makes
+        // interpreting the state easier for external consumers that don't have access to the id map.
+        let mut sorted_keys: Vec<usize> = self.id_map.keys().copied().collect();
+        self.flush_queue(&sorted_keys, FlushLevel::HRxRy);
+
+        sorted_keys.sort_unstable();
+        sorted_keys.iter().enumerate().for_each(|(index, &key)| {
+            if index != self.id_map[&key] {
+                self.swap_qubit_state(self.id_map[&key], index);
+                let swapped_key = *self
+                    .id_map
+                    .iter()
+                    .find(|(_, &value)| value == index)
+                    .unwrap()
+                    .0;
+                *(self.id_map.get_mut(&swapped_key).unwrap()) = self.id_map[&key];
+                *(self.id_map.get_mut(&key).unwrap()) = index;
+            }
+        });
+
+        self.state.clone().drain().collect()
+    }
+
     /// Allocates a fresh qubit, returning its identifier. Note that this will use the lowest available
     /// identifier, and may result in qubits being allocated "in the middle" of an existing register
     /// if those identifiers are available.


### PR DESCRIPTION
This change adds support for a Rust API to capture the quantum state such that it can be used for verbose output in Rust compatible environments. This avoids the need to marshal the quantum state into C-compatible types across FFI with QIR.