### PR TITLE
Update rotations to use alternate phase convention

### DIFF
--- a/backend/src/simulator.rs
+++ b/backend/src/simulator.rs
@@ -1544,4 +1544,21 @@ mod tests {
             3,
         );
     }
+
+    #[test]
+    fn test_rz_phase_convention() {
+        let mut sim = QuantumSim::default();
+        let q0 = sim.allocate();
+        sim.z(q0);
+        let z_state = sim.get_state();
+        let mut sim = QuantumSim::default();
+        let q0 = sim.allocate();
+        sim.rz(PI, q0);
+        let rzpi_state = sim.get_state();
+        assert_eq!(z_state.len(), 1);
+        assert_eq!(rzpi_state.len(), 1);
+        assert_eq!(z_state[0].0, rzpi_state[0].0);
+        assert!(almost_equal(z_state[0].1.re, rzpi_state[0].1.re));
+        assert!(almost_equal(z_state[0].1.im, rzpi_state[0].1.im));
+    }
 }


### PR DESCRIPTION
This change updates the behavior of the qir-backend `__quantum__qis__rz__body` to respect an alternate global phase convention, namely that it avoids introducing the phase of `i` in the quantum state. To make this approach consistent across other gates, the internal `mcrotation` function now also incorporates phase in the special case where the rotation matrix entries are nearly zero.

Fixes #62