### PR TITLE
Include allocated qubit count in state capture

### DIFF
--- a/backend/src/simulator.rs
+++ b/backend/src/simulator.rs
@@ -69,8 +69,10 @@ impl QuantumSim {
         }
     }
 
+    /// Returns a sorted copy of the current sparse state as a vector of pairs of indices and complex numbers, along with
+    /// the total number of currently allocated qubits to help in interpreting the sparse state.
     #[must_use]
-    pub(crate) fn get_state(&mut self) -> Vec<(BigUint, Complex64)> {
+    pub(crate) fn get_state(&mut self) -> (Vec<(BigUint, Complex64)>, usize) {
         // Swap all the entries in the state to be ordered by qubit identifier. This makes
         // interpreting the state easier for external consumers that don't have access to the id map.
         let mut sorted_keys: Vec<usize> = self.id_map.keys().copied().collect();
@@ -91,7 +93,9 @@ impl QuantumSim {
             }
         });
 
-        self.state.clone().drain().collect()
+        let mut state: Vec<(BigUint, Complex64)> = self.state.clone().drain().collect();
+        state.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        (state, sorted_keys.len())
     }
 
     /// Allocates a fresh qubit, returning its identifier. Note that this will use the lowest available

--- a/backend/src/simulator.rs
+++ b/backend/src/simulator.rs
@@ -93,7 +93,7 @@ impl QuantumSim {
             }
         });
 
-        let mut state: Vec<(BigUint, Complex64)> = self.state.clone().drain().collect();
+        let mut state = self.state.clone().drain().collect::<Vec<_>>();
         state.sort_unstable_by(|a, b| a.0.cmp(&b.0));
         (state, sorted_keys.len())
     }


### PR DESCRIPTION
This updates the output of `capture_quantum_state` to return the total number of currently allocated qubits alongside the sparse state. It also updates the sparse state to be sorted by index/key to make it easier for consumers.