### PR TITLE
Make implementation of rt__message a (default) feature

### DIFF
--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -17,7 +17,9 @@ llvm-tools = { version = "0.1.1", optional = true}
 crate-type = ["staticlib", "rlib"]
 
 [features]
-default = ["fail-support"]
+default = ["fail-support", "message-support"]
 range-support = ["llvm-tools"]
 # Enables a default implementation of __quantum__rt__fail that panics with the fail message.
-fail-support = []
+fail-support = ["message-support"]
+# Enables a default implementation of __quantum__rt__message that prints the mssage to stdout.
+message-support = []

--- a/stdlib/src/lib.rs
+++ b/stdlib/src/lib.rs
@@ -83,6 +83,7 @@ pub unsafe extern "C" fn __quantum__rt__fail(str: *const CString) {
     panic!("{}", (*str).to_str().expect("Unable to convert string"));
 }
 
+#[cfg(feature = "message-support")]
 #[no_mangle]
 pub unsafe extern "C" fn __quantum__rt__message(str: *const CString) {
     println!("{}", (*str).to_str().expect("Unable to convert string"));


### PR DESCRIPTION
Similar to how we can provide a custom implementation to `rt__fail` this makes the implementation of `rt__message` a default feature.