### PR TITLE
Preserve queued rotations across id swap

### DIFF
--- a/backend/src/simulator.rs
+++ b/backend/src/simulator.rs
@@ -1305,6 +1305,32 @@ mod tests {
         assert!(sim.joint_probability(&[q2]).is_nearly_zero());
     }
 
+    /// Verify that two queued Rx rotations that sum to zero are treated as
+    /// a no-op.
+    #[test]
+    fn test_rx_queue_nearly_zero() {
+        let mut sim = QuantumSim::new();
+        let q = sim.allocate();
+        sim.rx(PI / 4.0, q);
+        assert_eq!(sim.state.len(), 1);
+        sim.rx(-PI / 4.0, q);
+        assert_eq!(sim.state.len(), 1);
+        assert!(sim.joint_probability(&[q]).is_nearly_zero());
+    }
+
+    /// Verify that two queued Ry rotations that sum to zero are treated as
+    /// a no-op.
+    #[test]
+    fn test_ry_queue_nearly_zero() {
+        let mut sim = QuantumSim::new();
+        let q = sim.allocate();
+        sim.ry(PI / 4.0, q);
+        assert_eq!(sim.state.len(), 1);
+        sim.ry(-PI / 4.0, q);
+        assert_eq!(sim.state.len(), 1);
+        assert!(sim.joint_probability(&[q]).is_nearly_zero());
+    }
+
     /// Utility for testing operation equivalence.
     fn assert_operation_equal_referenced<F1, F2>(mut op: F1, mut reference: F2, count: usize)
     where


### PR DESCRIPTION
This change fixes an issue with `swap_qubit_ids` that could cause queued rotations on swapped qubits to get lost. The updated logic correctly queries the maps before applying changes and updates the right qubits with the right values. It also introduces a test case that verifies swapping respects queued rotations, and slightly optimizes the queuing of `rx` rotations.