### PR TITLE
Fix nightly builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,9 +673,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
This fixes the nightly builds by forcing use of a newer version of the proc-macro2 dependency.

See https://github.com/rust-lang/rust/issues/113152.