### PR TITLE
Create the qir-stdlib artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,15 @@ jobs:
         run: cargo build -vv --release
       - name: Test
         run: cargo test -vv --release -- --nocapture
+      - name: qir-stdlib Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: qir-stdlib-${{ matrix.config.os }}-${{ matrix.config.arch }}-artifacts
+          path: |
+            target/release/libqir_stdlib.a
+            stdlib/include/*
+            runner/NOTICE.txt
+            LICENSE
       - name: Artifacts executable
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,22 +123,49 @@ jobs:
         run: cargo build -vv --release
       - name: Test
         run: cargo test -vv --release -- --nocapture
-      - name: qir-stdlib Artifact
+      # qir-stdlib Artifact
+      - name: qir-stdlib Artifact (Library)
+        if: ${{ matrix.config.os != 'windows-2019' }}
         uses: actions/upload-artifact@v3
         with:
           name: qir-stdlib-${{ matrix.config.os }}-${{ matrix.config.arch }}-artifacts
-          path: |
-            target/release/libqir_stdlib.a
-            stdlib/include/qir_stdlib.def
-            stdlib/include/qir_stdlib.h
-            runner/NOTICE.txt
-            LICENSE
+          path: target/release/libqir_stdlib.a
+      - name: qir-stdlib Artifact (Library on Windows)
+        if: ${{ matrix.config.os == 'windows-2019' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: qir-stdlib-${{ matrix.config.os }}-${{ matrix.config.arch }}-artifacts
+          path: target/release/libqir_stdlib.lib
+      - name: qir-stdlib Artifact (Definition file)
+        if: ${{ matrix.config.os == 'windows-2019' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: qir-stdlib-${{ matrix.config.os }}-${{ matrix.config.arch }}-artifacts
+          path: stdlib/include/qir_stdlib.def
+      - name: qir-stdlib Artifact (Header file)
+        uses: actions/upload-artifact@v3
+        with:
+          name: qir-stdlib-${{ matrix.config.os }}-${{ matrix.config.arch }}-artifacts
+          path: stdlib/include/qir_stdlib.h
+      - name: qir-stdlib Artifact (Notice file)
+        uses: actions/upload-artifact@v3
+        with:
+          name: qir-stdlib-${{ matrix.config.os }}-${{ matrix.config.arch }}-artifacts
+          path: runner/NOTICE.txt
+      - name: qir-stdlib Artifact (License file)
+        uses: actions/upload-artifact@v3
+        with:
+          name: qir-stdlib-${{ matrix.config.os }}-${{ matrix.config.arch }}-artifacts
+          path: LICENSE
+      # qir-runner Artifact
       - name: Artifacts executable
+        if: ${{ matrix.config.os != 'windows-2019' }}
         uses: actions/upload-artifact@v3
         with:
           name: qir-runner-${{ matrix.config.os }}-${{ matrix.config.arch }}-artifacts
           path: target/release/qir-runner
       - name: Artifacts executable (Windows)
+        if: ${{ matrix.config.os == 'windows-2019' }}
         uses: actions/upload-artifact@v3
         with:
           name: qir-runner-${{ matrix.config.os }}-${{ matrix.config.arch }}-artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: qir-stdlib-${{ matrix.config.os }}-${{ matrix.config.arch }}-artifacts
-          path: target/release/libqir_stdlib.lib
+          path: target/release/qir_stdlib.lib
       - name: qir-stdlib Artifact (Definition file)
         if: ${{ matrix.config.os == 'windows-2019' }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,8 @@ jobs:
           name: qir-stdlib-${{ matrix.config.os }}-${{ matrix.config.arch }}-artifacts
           path: |
             target/release/libqir_stdlib.a
-            stdlib/include/*
+            stdlib/include/qir_stdlib.def
+            stdlib/include/qir_stdlib.h
             runner/NOTICE.txt
             LICENSE
       - name: Artifacts executable


### PR DESCRIPTION
**Context:**
The sparse quantum state simulator in the `qir-runner` is backed by `qir-stdlib`. This library can serve as the foundational implementation for QIR instructions across various quantum runtimes that adhere to the QIR specifications. For instance, the C++ quantum runtime in [PennyLane-Catalyst](https://github.com/PennyLaneAI/catalyst) leverages `libqir_stdlib.a` for implementation of basic QIR instructions.

However, it's important to note that the official release of neither `libqir_stdlib.a` nor `libqir_stdlib.so` are yet available. Consequently, for any other quantum runtime aiming to include the `qir-stdlib`, it is necessary to install the Rust compiler and build the package with dependencies on the machine. To remove this complexity, we would like to propose including the qir-stdlib artifact as part of the release; therefore facilitating the process for integrating the library into third-party quantum runtimes.


**Description of the Change:**

This primarily necessitates the creation of the `qir-stdlib` artifact  including `libqir_stdlib.a`, `qir_stdlib.h` and `qir_stdlib.def`.

**Benefits:**

The release of `qir-stdlib` would enable both first- and third-party contributors to utilize and expand upon the standard in other runtimes and simulators that incorporate the QIR interface without any requirements to clone and build the source code.

In addition, this would mitigate users from the need to install the Rust compiler and packages, especially considering that not all quantum runtime ecosystems are implemented in Rust.