### PR TITLE
Use macos-14 runner

### DIFF
--- a/.github/actions/install-llvm/action.yml
+++ b/.github/actions/install-llvm/action.yml
@@ -37,7 +37,7 @@ runs:
     - name: MacOS - Install build dependencies, ninja
       run: brew install ninja
       shell: pwsh
-      if: ${{ (inputs.os == 'macos-11') && (steps.cache-llvm.outputs.cache-hit != 'true') }}
+      if: ${{ (inputs.os == 'macos-11' || inputs.os == 'macos-14') && (steps.cache-llvm.outputs.cache-hit != 'true') }}
     - name: Windows - Install LLVM 14.0.6
       run: choco install llvm --version=14.0.6 --allow-downgrade
       shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,7 @@ jobs:
           - { os: "ubuntu-22.04", arch: "amd64" }
           - { os: "windows-2019", arch: "amd64" }
           - { os: "macos-11", arch: "amd64" }
+          - { os: "macos-14", arch: "arm64" }
     steps:
       - uses: actions/checkout@v3
       - name: Setup rust toolchain


### PR DESCRIPTION
This sets up the macos-14 runner in the CI pipeline for testing and producing artifacts.