### PR TITLE
Fix multicontrolled Ri, tests

### DIFF
--- a/sparsesim/src/lib.rs
+++ b/sparsesim/src/lib.rs
@@ -662,8 +662,9 @@ impl QuantumSim {
     pub fn mcphase(&mut self, ctls: &[usize], phase: Complex64, target: usize) {
         self.flush_queue(ctls, FlushLevel::HRxRy);
         self.flush_queue(&[target], FlushLevel::HRxRy);
-        self.controlled_gate(ctls, target, |(index, val), target| {
-            Self::phase_transform(phase, (index, val), target)
+        self.controlled_gate(ctls, target, |(index, val), _| {
+            let val = val * phase;
+            (index, val)
         });
     }
 

--- a/sparsesim/src/matrix_testing.rs
+++ b/sparsesim/src/matrix_testing.rs
@@ -385,36 +385,37 @@ mod tests {
     {
         let mut sim = QuantumSim::default();
 
-        // Allocte the control we use to verify behavior.
-        let ctl = sim.allocate();
-        sim.h(ctl);
-
+        // Allocte the controls we use to verify behavior.
         // Allocate the requested number of targets, entangling the control with them.
+        let mut ctls = vec![];
         let mut qs = vec![];
         for _ in 0..count {
+            let ctl = sim.allocate();
             let q = sim.allocate();
+            sim.h(ctl);
             sim.mcx(&[ctl], q);
             qs.push(q);
+            ctls.push(ctl);
         }
 
         op(&mut sim, &qs);
         reference(&mut sim, &qs);
 
         // Undo the entanglement.
-        for q in &qs {
-            sim.mcx(&[ctl], *q);
+        for (q, ctl) in qs.iter().zip(&ctls) {
+            sim.mcx(&[*ctl], *q);
+            sim.h(*ctl);
         }
-        sim.h(ctl);
+
+        sim.dump();
 
         // We know the operations are equal if the qubits are left in the zero state.
-        assert!(sim.joint_probability(&[ctl]).is_nearly_zero());
-        for q in qs {
-            assert!(sim.joint_probability(&[q]).is_nearly_zero());
+        for (q, ctl) in qs.iter().zip(&ctls) {
+            assert!(sim.joint_probability(&[*q]).is_nearly_zero());
+            assert!(sim.joint_probability(&[*ctl]).is_nearly_zero());
         }
 
         // Sparse state vector should have one entry for |0⟩.
-        // Dump the state first to force a flush of any queued operations.
-        sim.dump();
         assert_eq!(sim.state.len(), 1);
     }
 


### PR DESCRIPTION
The test utility for comparing simulator functions against matrix applications was not using enough qubits to fully verify the resulting state, and fixing this revealed a bug in the way `mcphase` was used to implement a multicontrolled Ri rotation (the phase was not applied globally). This change updates the tests and fixes `mcphase` to apply to all states instead of just states with a 1 in the computational basis.