### PR TITLE
Add workflow_dispatch to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
       - main
       - release/*
       - feature/*
+  workflow_dispatch:
 
 env:
   RUSTDOCFLAGS: -Dwarnings


### PR DESCRIPTION
This allows triggering CI pipelines manually without needing to create a PR.