### PR TITLE
Include global phase of -i for Rx/Ry of Pi

### DIFF
--- a/sparsesim/src/lib.rs
+++ b/sparsesim/src/lib.rs
@@ -957,15 +957,15 @@ impl QuantumSim {
             }
             // Rx/Ry are different from X/Y by a global phase of -i, so apply that here for mathematical correctness.
             let (_, ctls) = self.resolve_and_check_qubits(target, ctls);
-            self.state = self
-                .state
-                .drain()
-                .fold(SparseState::default(), |mut accum, (index, value)| {
-                    if ctls.iter().all(|c| index.bit(*c)) {
-                        accum.insert(index, value * -Complex64::i());
-                    }
-                    accum
-                });
+            self.state =
+                self.state
+                    .drain()
+                    .fold(SparseState::default(), |mut accum, (index, value)| {
+                        if ctls.iter().all(|c| index.bit(*c)) {
+                            accum.insert(index, value * -Complex64::i());
+                        }
+                        accum
+                    });
         } else if m01.is_nearly_zero() {
             // This is just identity, so we can no-op.
         } else {

--- a/sparsesim/src/lib.rs
+++ b/sparsesim/src/lib.rs
@@ -955,6 +955,17 @@ impl QuantumSim {
             } else {
                 self.mcx(ctls, target);
             }
+            // Rx/Ry are different from X/Y by a global phase of -i, so apply that here for mathematical correctness.
+            let (_, ctls) = self.resolve_and_check_qubits(target, ctls);
+            self.state = self
+                .state
+                .drain()
+                .fold(SparseState::default(), |mut accum, (index, value)| {
+                    if ctls.iter().all(|c| index.bit(*c)) {
+                        accum.insert(index, value * -Complex64::i());
+                    }
+                    accum
+                });
         } else if m01.is_nearly_zero() {
             // This is just identity, so we can no-op.
         } else {

--- a/sparsesim/src/matrix_testing.rs
+++ b/sparsesim/src/matrix_testing.rs
@@ -417,6 +417,8 @@ mod tests {
 
         // Sparse state vector should have one entry for |0⟩.
         assert_eq!(sim.state.len(), 1);
+        // If the operations are equal including the phase, the entry should be 1.
+        assert!((sim.state.values().next().unwrap() - Complex64::one()).is_nearly_zero());
     }
 
     #[test]
@@ -550,6 +552,19 @@ mod tests {
     }
 
     #[test]
+    fn test_rz_pi() {
+        assert_operation_equal_referenced(
+            |sim, qs| {
+                sim.rz(PI, qs[0]);
+            },
+            |sim, qs| {
+                sim.apply(&adjoint(&rz(PI)), &[qs[0]], None);
+            },
+            1,
+        );
+    }
+
+    #[test]
     fn test_rx() {
         assert_operation_equal_referenced(
             |sim, qs| {
@@ -563,6 +578,19 @@ mod tests {
     }
 
     #[test]
+    fn test_rx_pi() {
+        assert_operation_equal_referenced(
+            |sim, qs| {
+                sim.rx(PI, qs[0]);
+            },
+            |sim, qs| {
+                sim.apply(&adjoint(&rx(PI)), &[qs[0]], None);
+            },
+            1,
+        );
+    }
+
+    #[test]
     fn test_ry() {
         assert_operation_equal_referenced(
             |sim, qs| {
@@ -570,6 +598,19 @@ mod tests {
             },
             |sim, qs| {
                 sim.apply(&adjoint(&ry(PI / 7.0)), &[qs[0]], None);
+            },
+            1,
+        );
+    }
+
+    #[test]
+    fn test_ry_pi() {
+        assert_operation_equal_referenced(
+            |sim, qs| {
+                sim.ry(PI, qs[0]);
+            },
+            |sim, qs| {
+                sim.apply(&adjoint(&ry(PI)), &[qs[0]], None);
             },
             1,
         );


### PR DESCRIPTION
This fixes the shortcut used to optimize Rx/Ry of Pi, where we offload to X/Y, by ensuring the expected global phase of i is included. This also includes new matrix-based unit tests that verify the expected behavior is mathematically correct.

Fixes #162