### PR TITLE
Remove optional qir-stdlib dependency for sparse sim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,6 @@ dependencies = [
  "num-bigint",
  "num-complex",
  "num-traits",
- "qir-stdlib",
  "rand",
  "rustc-hash",
 ]

--- a/backend/src/exp.rs
+++ b/backend/src/exp.rs
@@ -28,7 +28,6 @@ fn map_pauli(pauli: Pauli) -> SparsePauli {
     }
 }
 
-
 /// QIR API for applying an exponential of a multi-qubit rotation about the given Pauli axes with the given angle and qubits.
 /// # Safety
 ///
@@ -45,7 +44,9 @@ pub unsafe extern "C" fn __quantum__qis__exp__body(
 
         let paulis_size = __quantum__rt__array_get_size_1d(paulis);
         let paulis: Vec<SparsePauli> = (0..paulis_size)
-            .map(|index| map_pauli(*__quantum__rt__array_get_element_ptr_1d(paulis, index).cast::<Pauli>()))
+            .map(|index| {
+                map_pauli(*__quantum__rt__array_get_element_ptr_1d(paulis, index).cast::<Pauli>())
+            })
             .collect();
 
         let qubits_size = __quantum__rt__array_get_size_1d(qubits);
@@ -110,7 +111,9 @@ pub unsafe extern "C" fn __quantum__qis__exp__ctl(
         let paulis_size = __quantum__rt__array_get_size_1d(args.paulis);
         let paulis: Vec<SparsePauli> = (0..paulis_size)
             .map(|index| {
-                map_pauli(*__quantum__rt__array_get_element_ptr_1d(args.paulis, index).cast::<Pauli>())
+                map_pauli(
+                    *__quantum__rt__array_get_element_ptr_1d(args.paulis, index).cast::<Pauli>(),
+                )
             })
             .collect();
 

--- a/backend/src/exp.rs
+++ b/backend/src/exp.rs
@@ -13,10 +13,21 @@ use qir_stdlib::{
     tuples::{__quantum__rt__tuple_create, __quantum__rt__tuple_update_reference_count},
     Pauli,
 };
+use quantum_sparse_sim::exp::Pauli as SparsePauli;
 use std::{
     mem::size_of,
     os::raw::{c_double, c_void},
 };
+
+fn map_pauli(pauli: Pauli) -> SparsePauli {
+    match pauli {
+        Pauli::I => SparsePauli::I,
+        Pauli::X => SparsePauli::X,
+        Pauli::Z => SparsePauli::Z,
+        Pauli::Y => SparsePauli::Y,
+    }
+}
+
 
 /// QIR API for applying an exponential of a multi-qubit rotation about the given Pauli axes with the given angle and qubits.
 /// # Safety
@@ -33,8 +44,8 @@ pub unsafe extern "C" fn __quantum__qis__exp__body(
         let state = &mut *sim_state.borrow_mut();
 
         let paulis_size = __quantum__rt__array_get_size_1d(paulis);
-        let paulis: Vec<Pauli> = (0..paulis_size)
-            .map(|index| *__quantum__rt__array_get_element_ptr_1d(paulis, index).cast::<Pauli>())
+        let paulis: Vec<SparsePauli> = (0..paulis_size)
+            .map(|index| map_pauli(*__quantum__rt__array_get_element_ptr_1d(paulis, index).cast::<Pauli>()))
             .collect();
 
         let qubits_size = __quantum__rt__array_get_size_1d(qubits);
@@ -97,9 +108,9 @@ pub unsafe extern "C" fn __quantum__qis__exp__ctl(
             .collect();
 
         let paulis_size = __quantum__rt__array_get_size_1d(args.paulis);
-        let paulis: Vec<Pauli> = (0..paulis_size)
+        let paulis: Vec<SparsePauli> = (0..paulis_size)
             .map(|index| {
-                *__quantum__rt__array_get_element_ptr_1d(args.paulis, index).cast::<Pauli>()
+                map_pauli(*__quantum__rt__array_get_element_ptr_1d(args.paulis, index).cast::<Pauli>())
             })
             .collect();
 

--- a/sparsesim/Cargo.toml
+++ b/sparsesim/Cargo.toml
@@ -6,14 +6,9 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-qir-stdlib = { path = "../stdlib", optional = true }
 rand = "0.8.5"
 rustc-hash = "1.1.0"
 num-complex = "0.4"
 num-traits = "0.2.19"
 num-bigint = { version = "0.4.5", default-features = false }
 ndarray = "0.15.4"
-
-[features]
-default = ["exp"]
-exp = ["qir-stdlib"]

--- a/sparsesim/src/exp.rs
+++ b/sparsesim/src/exp.rs
@@ -10,10 +10,16 @@
 use num_bigint::BigUint;
 use num_complex::Complex64;
 use num_traits::{One, Zero};
-use qir_stdlib::Pauli;
 use std::ops::ControlFlow;
 
 use crate::{nearly_zero::NearlyZero, FlushLevel, QuantumSim, SparseState};
+
+pub enum Pauli {
+    I,
+    X,
+    Z,
+    Y,
+}
 
 impl QuantumSim {
     /// Exp multi-qubit rotation gate.

--- a/sparsesim/src/lib.rs
+++ b/sparsesim/src/lib.rs
@@ -7,8 +7,8 @@
 //! This libary implements sparse state simulation, based on the design from
 //! <a href="https://arxiv.org/abs/2105.01533">Leveraging state sparsity for more efficient quantum simulations</a>.
 
-mod nearly_zero;
 pub mod exp;
+mod nearly_zero;
 
 // Additional test infrastructure is available in matrix_testing that allows comparing the transformations
 // implemented here with direct matrix application to the state vector.

--- a/sparsesim/src/lib.rs
+++ b/sparsesim/src/lib.rs
@@ -8,8 +8,6 @@
 //! <a href="https://arxiv.org/abs/2105.01533">Leveraging state sparsity for more efficient quantum simulations</a>.
 
 mod nearly_zero;
-
-#[cfg(feature = "exp")]
 pub mod exp;
 
 // Additional test infrastructure is available in matrix_testing that allows comparing the transformations


### PR DESCRIPTION
This simplifies dependencies by mapping in `Pauli` in backend crate rather than the sparsesim create depending on qir-stdlib.