### PR TITLE
Clean up repo and dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: cargo
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 [[package]]
 name = "inkwell"
 version = "0.4.0"
-source = "git+https://github.com/TheDan64/inkwell?branch=master#5c9f7fcbb0a667f7391b94beb65f1a670ad13221"
+source = "git+https://github.com/TheDan64/inkwell?rev=0.4.0#ad2a27dd660fc7ddb6144bb0865267e02f192dd5"
 dependencies = [
  "either",
  "inkwell_internals",
@@ -345,7 +345,7 @@ dependencies = [
 [[package]]
 name = "inkwell_internals"
 version = "0.9.0"
-source = "git+https://github.com/TheDan64/inkwell?branch=master#5c9f7fcbb0a667f7391b94beb65f1a670ad13221"
+source = "git+https://github.com/TheDan64/inkwell?rev=0.4.0#ad2a27dd660fc7ddb6144bb0865267e02f192dd5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "qirrunner"
-version = "0.0.0"
+version = "0.7.1"
 dependencies = [
  "pyo3",
  "runner",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,26 @@ members = [
 ]
 resolver = "2"
 
+[workspace.package]
+authors = ["Microsoft"]
+homepage = "https://github.com/qir-alliance/qir-runner"
+repository = "https://github.com/qir-alliance/qir-runner"
+edition = "2021"
+license = "MIT"
+version = "0.7.1"
+
 [profile.release]
 debug = 1
 
 [workspace.dependencies]
+bitvec = "1.0.0"
+clap = { version = "4.5.7", features = [ "cargo" ] }
+criterion = "0.5.1"
+msvc_spectre_libs = { version = "0.1", features = [ "error" ] }
+ndarray = "0.15.4"
+num-bigint = { version = "0.4.6", default-features = false }
+num-complex = "0.4"
+num-traits = "0.2.19"
 pyo3 = "0.20"
+rand = "0.8.5"
+rustc-hash = "1.1.0"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,20 +1,22 @@
 [package]
 name = "qir-backend"
-version = "0.7.1"
-authors = ["Microsoft"]
-edition = "2021"
-license = "MIT"
+version.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 qir-stdlib = { path = "../stdlib" }
 quantum-sparse-sim = { path = "../sparsesim" }
-rand = "0.8.5"
-num-complex = "0.4"
-num-bigint = { version = "0.4.6", default-features = false }
-bitvec = "1.0.0"
+rand = { workspace = true }
+num-complex = { workspace = true }
+num-bigint = { workspace = true }
+bitvec = { workspace = true }
 
 [dev-dependencies]
-criterion = "0.5.1"
+criterion = { workspace = true }
 
 [[bench]]
 name = "gates"

--- a/pip/Cargo.toml
+++ b/pip/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-authors = ["Microsoft"]
 name = "qirrunner"
-version = "0.0.0"
-edition = "2021"
-license = "MIT"
 description = "JIT compiles and executes programs written in QIR (Quantum Intermediate Representation)."
 readme = "README.md"
-homepage = "https://github.com/qir-alliance/qir-runner"
-repository = "https://github.com/qir-alliance/qir-runner"
+version.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 runner = { path = "../runner" }

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -1,20 +1,23 @@
 [package]
 name = "runner"
-version = "0.7.1"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies.inkwell]
 git = "https://github.com/TheDan64/inkwell"
-branch = "master"
+rev = "0.4.0"
 default-features = false
 features = ["llvm14-0"]
 
 [dependencies]
 qir-stdlib = { path = "../stdlib" }
 qir-backend = { path = "../backend" }
-clap = { version = "4.5.8", features = [ "cargo" ] }
-msvc_spectre_libs = { version = "0.1", features = ["error"] }
+clap = { workspace = true }
+msvc_spectre_libs = { workspace = true }
 
 [[bin]]
 name = "qir-runner"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "1.75"
-components = [ "rustfmt", "clippy", "llvm-tools-preview" ]

--- a/sparsesim/Cargo.toml
+++ b/sparsesim/Cargo.toml
@@ -1,14 +1,16 @@
 [package]
 name = "quantum-sparse-sim"
-version = "0.7.1"
-authors = ["Microsoft"]
-edition = "2021"
-license = "MIT"
+version.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
-rand = "0.8.5"
-rustc-hash = "1.1.0"
-num-complex = "0.4"
-num-traits = "0.2.19"
-num-bigint = { version = "0.4.6", default-features = false }
-ndarray = "0.15.4"
+rand = { workspace = true }
+rustc-hash = { workspace = true }
+num-complex = { workspace = true }
+num-traits = { workspace = true }
+num-bigint = { workspace = true }
+ndarray = { workspace = true }

--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -1,14 +1,16 @@
 [package]
 name = "qir-stdlib"
-version = "0.7.1"
-authors = ["Microsoft"]
-edition = "2021"
-license = "MIT"
 links = "qir-stdlib"
+version.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
-num-bigint = { version = "0.4.6", default-features = false }
-rand = "0.8.5"
+num-bigint = { workspace = true }
+rand = { workspace = true }
 
 [lib]
 crate-type = ["staticlib", "rlib"]

--- a/stdlib/src/arrays.rs
+++ b/stdlib/src/arrays.rs
@@ -43,7 +43,7 @@ pub unsafe extern "C" fn __quantum__rt__array_copy(
         let copy = rc.as_ref().clone();
         Rc::into_raw(Rc::new(copy))
     } else {
-        Rc::into_raw(Rc::clone(&rc));
+        let _ = Rc::into_raw(Rc::clone(&rc));
         arr
     }
 }

--- a/stdlib/src/callables.rs
+++ b/stdlib/src/callables.rs
@@ -111,7 +111,7 @@ pub unsafe extern "C" fn __quantum__rt__callable_copy(
         let copy = rc.as_ref().clone();
         Rc::into_raw(Rc::new(copy))
     } else {
-        Rc::into_raw(Rc::clone(&rc));
+        let _ = Rc::into_raw(Rc::clone(&rc));
         callable
     }
 }

--- a/stdlib/src/output_recording.rs
+++ b/stdlib/src/output_recording.rs
@@ -45,22 +45,6 @@ impl Read for OutputRecorder {
     }
 }
 
-struct DefaultReaderWriter(Vec<u8>);
-impl Write for DefaultReaderWriter {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.0.write(buf)
-    }
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.0.flush()
-    }
-}
-
-impl Read for DefaultReaderWriter {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        self.0.as_slice().read(buf)
-    }
-}
-
 impl Default for OutputRecorder {
     fn default() -> Self {
         OutputRecorder {

--- a/stdlib/src/tuples.rs
+++ b/stdlib/src/tuples.rs
@@ -38,7 +38,7 @@ pub unsafe extern "C" fn __quantum__rt__tuple_copy(
         *header = Rc::into_raw(Rc::new(copy));
         header.wrapping_add(1)
     } else {
-        Rc::into_raw(Rc::clone(&rc));
+        let _ = Rc::into_raw(Rc::clone(&rc));
         raw_tup
     }
 }


### PR DESCRIPTION
This PR makes several changes to clean-up/streamline the repository:

 - Moves package version, authos, edition, and license to the workspace level to make updates easier.
 - Moves all dependency version specification to the workspace to make tracking and updating dependencies easier.
 - Removes dependabot.yml in favor of manual updates, so syncing with ADO release builds crate availability is easier.
 - Downgrades clap to 4.5.7 for compatibility with ADO.
 - Removes the rust toolchain file and fixes clippy warnings for 1.78.
 - Pins to specific release of inkwell rather than using branch master for better predictability.