### PR TITLE
Fix leftover global phase when all qubits released

### DIFF
--- a/sparsesim/src/index_map.rs
+++ b/sparsesim/src/index_map.rs
@@ -48,7 +48,7 @@ impl<K, V> IndexMap<K, V> {
 
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.values.is_empty()
+        self.values.iter().all(std::option::Option::is_none)
     }
 
     // `Iter` does implement `Iterator`, but it has an additional bound on `K`.

--- a/sparsesim/src/lib.rs
+++ b/sparsesim/src/lib.rs
@@ -1988,4 +1988,20 @@ mod tests {
             2,
         );
     }
+
+    #[test]
+    fn test_global_phase_dropped_when_all_qubits_released() {
+        let mut sim = QuantumSim::default();
+        let q = sim.allocate();
+        sim.x(q);
+        sim.z(q);
+        sim.release(q);
+        let _ = sim.allocate();
+        let (state, count) = sim.get_state();
+        assert_eq!(count, 1);
+        assert_eq!(state.len(), 1);
+        let (index, value) = state.first().unwrap();
+        assert_eq!(index, &BigUint::zero());
+        assert_eq!(value, &Complex64::one());
+    }
 }


### PR DESCRIPTION
The change to use `IndexMap` incorrectly left the older implementation of `is_empty` that didn't account for `None` entries. This meant the handling for dropping the state vector when all qubits are released stopped working and could lead to leftover global phase propagating to newly allocated qubits.