### PR TITLE
Resolve elided lifetime warnings

### DIFF
--- a/sparsesim/src/index_map.rs
+++ b/sparsesim/src/index_map.rs
@@ -54,7 +54,7 @@ impl<K, V> IndexMap<K, V> {
     // `Iter` does implement `Iterator`, but it has an additional bound on `K`.
     #[allow(clippy::iter_not_returning_iterator)]
     #[must_use]
-    pub fn iter(&self) -> Iter<K, V> {
+    pub fn iter(&self) -> Iter<'_, K, V> {
         Iter {
             _keys: PhantomData,
             base: self.values.iter().enumerate(),
@@ -63,14 +63,14 @@ impl<K, V> IndexMap<K, V> {
 
     // `Iter` does implement `Iterator`, but it has an additional bound on `K`.
     #[allow(clippy::iter_not_returning_iterator)]
-    pub fn iter_mut(&mut self) -> IterMut<K, V> {
+    pub fn iter_mut(&mut self) -> IterMut<'_, K, V> {
         IterMut {
             _keys: PhantomData,
             base: self.values.iter_mut().enumerate(),
         }
     }
 
-    pub fn drain(&mut self) -> Drain<K, V> {
+    pub fn drain(&mut self) -> Drain<'_, K, V> {
         Drain {
             _keys: PhantomData,
             base: self.values.drain(..).enumerate(),
@@ -78,13 +78,13 @@ impl<K, V> IndexMap<K, V> {
     }
 
     #[must_use]
-    pub fn values(&self) -> Values<V> {
+    pub fn values(&self) -> Values<'_, V> {
         Values {
             base: self.values.iter(),
         }
     }
 
-    pub fn values_mut(&mut self) -> ValuesMut<V> {
+    pub fn values_mut(&mut self) -> ValuesMut<'_, V> {
         ValuesMut {
             base: self.values.iter_mut(),
         }

--- a/stdlib/src/output_recording.rs
+++ b/stdlib/src/output_recording.rs
@@ -67,7 +67,7 @@ impl OutputRecorder {
     }
 
     /// Drains the buffer and returns the contents.
-    pub fn drain(&mut self) -> std::vec::Drain<u8> {
+    pub fn drain(&mut self) -> std::vec::Drain<'_, u8> {
         self.buffer.drain(..)
     }
 }


### PR DESCRIPTION
Hola, señor Stefan. Thank you for your maintenance of this repository; it is very helpful.

This PR adds `'_` in a few places. Without this, I get several instances of the following warning when I compile:

        hiding a lifetime that's elided elsewhere is confusing

This is a harmless warning of course, but I live to please the compiler, what can I say.

### Testing

It still compiles and `cargo test` still passes.