### PR TITLE
Add proposed  `__quantum__rt__write_result` API

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -711,6 +711,23 @@ pub extern "C" fn __quantum__rt__read_result(result: *mut c_void) -> bool {
     __quantum__qis__read_result__body(result)
 }
 
+/// QIR API that writes the given Boolean value to the given result identifier, overwriting any previous value stored there.
+#[allow(clippy::missing_panics_doc)]
+// reason="Panics can only occur if the result index is not found in the BitVec after resizing, which should not happen."
+#[unsafe(no_mangle)]
+pub extern "C" fn __quantum__rt__write_result(value: bool, result: *mut c_void) {
+    SIM_STATE.with(|sim_state| {
+        let res = &mut sim_state.borrow_mut().res;
+        let res_id = result as usize;
+        if res.len() < res_id + 1 {
+            res.resize(res_id + 1, false);
+        }
+
+        *res.get_mut(res_id)
+            .expect("Result with given id missing after expansion.") = value;
+    });
+}
+
 /// QIR API that measures a given qubit in the computational basis, returning a runtime managed result value.
 #[unsafe(no_mangle)]
 pub extern "C" fn __quantum__qis__m__body(qubit: *mut c_void) -> *mut c_void {

--- a/pip/README.md
+++ b/pip/README.md
@@ -196,4 +196,5 @@ ptr @__quantum__rt__tuple_create(i64)
 void @__quantum__rt__tuple_record_output(i64, ptr)
 void @__quantum__rt__tuple_update_alias_count(ptr, i32)
 void @__quantum__rt__tuple_update_reference_count(ptr, i32)
+void @__quantum__rt__write_result(i1, ptr)
 ```

--- a/runner/README.md
+++ b/runner/README.md
@@ -149,4 +149,5 @@ ptr @__quantum__rt__tuple_create(i64)
 void @__quantum__rt__tuple_record_output(i64, ptr)
 void @__quantum__rt__tuple_update_alias_count(ptr, i32)
 void @__quantum__rt__tuple_update_reference_count(ptr, i32)
+void @__quantum__rt__write_result(i1, ptr)
 ```

--- a/runner/src/lib.rs
+++ b/runner/src/lib.rs
@@ -602,6 +602,7 @@ fn bind_functions(module: &Module, execution_engine: &ExecutionEngine) -> Result
     bind!(__quantum__rt__tuple_create, 1);
     bind!(__quantum__rt__tuple_update_alias_count, 2);
     bind!(__quantum__rt__tuple_update_reference_count, 2);
+    bind!(__quantum__rt__write_result, 2);
 
     if !(uses_legacy.iter().filter_map(|&b| b).all(|b| b)
         || uses_legacy.iter().filter_map(|&b| b).all(|b| !b))


### PR DESCRIPTION
This adds the result writing API proposed in https://github.com/qir-alliance/qir-spec/issues/65, enabling the use of allocated or static results with user provided default values or overridden values.